### PR TITLE
make getHelpId protected

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/AbstractStatisticsTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/AbstractStatisticsTopComponent.java
@@ -74,7 +74,7 @@ public abstract class AbstractStatisticsTopComponent extends TopComponent implem
 
     abstract protected PagePanel createPagePanel();
 
-    abstract String getHelpId();
+    abstract protected String getHelpId();
 
     @Override
     public void componentShowing() {

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/DensityPlotTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/DensityPlotTopComponent.java
@@ -61,7 +61,7 @@ public class DensityPlotTopComponent extends AbstractStatisticsTopComponent {
     }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_DensityPlotTopComponent_HelpId();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/GeoCodingTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/GeoCodingTopComponent.java
@@ -60,7 +60,7 @@ public class GeoCodingTopComponent extends AbstractStatisticsTopComponent {
     }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_GeoCodingTopComponent_HelpId();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/HistogramPlotTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/HistogramPlotTopComponent.java
@@ -61,7 +61,7 @@ public class HistogramPlotTopComponent extends AbstractStatisticsTopComponent {
     }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_HistogramPlotTopComponent_HelpId();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/InformationTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/InformationTopComponent.java
@@ -60,7 +60,7 @@ public class InformationTopComponent extends AbstractStatisticsTopComponent {
     }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_InformationTopComponent_HelpId();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/ProfilePlotTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/ProfilePlotTopComponent.java
@@ -78,7 +78,7 @@ public class ProfilePlotTopComponent extends AbstractStatisticsTopComponent {
 //    }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_ProfilePlotTopComponent_HelpId();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/ScatterPlotTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/ScatterPlotTopComponent.java
@@ -72,7 +72,7 @@ public class ScatterPlotTopComponent extends AbstractStatisticsTopComponent {
     }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_ScatterPlotTopComponent_HelpId();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/StatisticsTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/statistics/StatisticsTopComponent.java
@@ -41,7 +41,7 @@ public class StatisticsTopComponent extends AbstractStatisticsTopComponent {
     }
 
     @Override
-    String getHelpId() {
+    protected String getHelpId() {
         return Bundle.CTL_StatisticsTopComponent_HelpId();
     }
 


### PR DESCRIPTION
Make getHelpId protected so AbstractStatisticsTopComponent can be extended outside of the package