### PR TITLE
Added two context menu items

### DIFF
--- a/snap-ui/src/main/java/org/esa/snap/framework/ui/product/ProductTree.java
+++ b/snap-ui/src/main/java/org/esa/snap/framework/ui/product/ProductTree.java
@@ -19,6 +19,7 @@ import com.bc.ceres.swing.TreeCellExtender;
 import org.esa.snap.dataio.dimap.DimapProductReader;
 import org.esa.snap.framework.dataio.ProductIO;
 import org.esa.snap.framework.datamodel.Band;
+import org.esa.snap.framework.datamodel.FilterBand;
 import org.esa.snap.framework.datamodel.MetadataElement;
 import org.esa.snap.framework.datamodel.Product;
 import org.esa.snap.framework.datamodel.ProductManager;
@@ -551,6 +552,12 @@ public class ProductTree extends JTree implements PopupMenuFactory {
                 int componentCountBefore = popup.getComponentCount();
                 if (commandUIFactory != null) {
                     commandUIFactory.addContextDependentMenuItems("virtualBand", popup);
+                }
+                addSeparatorIfAnyComponentsAdded(popup, componentCountBefore);
+            } else if (context instanceof FilterBand) {
+                int componentCountBefore = popup.getComponentCount();
+                if (commandUIFactory != null) {
+                    commandUIFactory.addContextDependentMenuItems("filterBand", popup);
                 }
                 addSeparatorIfAnyComponentsAdded(popup, componentCountBefore);
             }

--- a/snap-visat-rcp/src/main/resources/module.xml
+++ b/snap-visat-rcp/src/main/resources/module.xml
@@ -573,6 +573,7 @@
             <smallIcon>icons/Save16.gif</smallIcon>
             <largeIcon>icons/Save24.gif</largeIcon>
             <helpId>save</helpId>
+            <context>product</context>
         </action>
 
         <action>
@@ -1262,7 +1263,7 @@
             <text>Convert Computed Band</text>
             <class>org.esa.snap.visat.actions.ConvertComputedBandIntoBandAction</class>
             <shortDescr>Computes a "real" band from a virtual band or filtered band</shortDescr>
-            <context>virtualBand</context>
+            <context>virtualBand,filterBand</context>
             <helpId>convertComputedBand2Band</helpId>
         </action>
 


### PR DESCRIPTION
I added "Convert Computed Band" to FilterBand objects' and "Save Product" to Product objects' context menu in the Product View window. Both of these menu items felt like they should already be there, but were not included for some reason.

The "Convert Computed Band" item will probably not work correctly at the moment due to the following issue: https://github.com/senbox-org/s1tbx/issues/9