### PR TITLE
add configuration for timeBeforeDialogAppears

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/file/ImportProductAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/file/ImportProductAction.java
@@ -65,6 +65,7 @@ public class ImportProductAction extends AbstractAction implements HelpCtx.Provi
         importProductAction.setFormatName((String) configuration.get("formatName"));
         importProductAction.setHelpCtx((String) configuration.get("helpId"));
         importProductAction.setUseAllFileFilter((Boolean) configuration.get("useAllFileFilter"));
+        importProductAction.setTimeBeforeDialogAppears((Integer) configuration.get("timeBeforeDialogAppears"));
         return importProductAction;
     }
 
@@ -93,6 +94,14 @@ public class ImportProductAction extends AbstractAction implements HelpCtx.Provi
         return Boolean.TRUE.equals(getValue("useAllFileFilter"));
     }
 
+    public void setTimeBeforeDialogAppears(Integer time) {
+        putValue("timeBeforeDialogAppears", time);
+    }
+
+    Integer getTimeBeforeDialogAppears() {
+        return (Integer) getValue("timeBeforeDialogAppears");
+    }
+
     @Override
     public void actionPerformed(ActionEvent e) {
         final ProductOpener opener = new ProductOpener();
@@ -100,6 +109,7 @@ public class ImportProductAction extends AbstractAction implements HelpCtx.Provi
         opener.setUseAllFileFilter(getUseAllFileFilter());
         opener.setMultiSelectionEnabled(false);
         opener.setSubsetImportEnabled(true);
+        opener.setTimeBeforeDialogAppears(getTimeBeforeDialogAppears());
         opener.openProduct();
     }
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/file/ProductOpener.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/file/ProductOpener.java
@@ -49,6 +49,7 @@ public class ProductOpener {
     private boolean subsetImportEnabled;
     private File[] files;
     private boolean multiSelectionEnabled;
+    private int dialogAfter = 2000;
 
     static List<File> getOpenedProductFiles() {
         return Arrays.stream(SnapApp.getDefault().getProductManager().getProducts())
@@ -93,6 +94,12 @@ public class ProductOpener {
         this.multiSelectionEnabled = multiSelectionEnabled;
     }
 
+    public void setTimeBeforeDialogAppears(final Integer time) {
+        if(time != null) {
+            this.dialogAfter = time;
+        }
+    }
+
     public boolean isMultiSelectionEnabled() {
         return multiSelectionEnabled;
     }
@@ -100,7 +107,7 @@ public class ProductOpener {
     public Boolean openProduct() {
         File[] configuredFiles = getFiles();
         if (configuredFiles != null) {
-            return openProductFilesCheckOpened(getFileFormat(), configuredFiles);
+            return openProductFilesCheckOpened(getFileFormat(), dialogAfter, configuredFiles);
         }
 
         Iterator<ProductReaderPlugIn> readerPlugIns;
@@ -175,7 +182,7 @@ public class ProductOpener {
                             ? ((SnapFileFilter) fc.getFileFilter()).getFormatName()
                             : null;
 
-        return openProductFilesCheckOpened(formatName, files);
+        return openProductFilesCheckOpened(formatName, dialogAfter, files);
     }
 
     private File[] getSelectedFiles(ProductFileChooser fc) {
@@ -191,7 +198,7 @@ public class ProductOpener {
         return files;
     }
 
-    private static Boolean openProductFilesCheckOpened(final String formatName, final File... files) {
+    private static Boolean openProductFilesCheckOpened(final String formatName, final int dialogAfter, final File... files) {
         List<File> openedFiles = getOpenedProductFiles();
         List<File> fileList = new ArrayList<>(Arrays.asList(files));
         for (File file : files) {
@@ -239,7 +246,7 @@ public class ProductOpener {
             }
 
 
-            Boolean status = openProductFileDoNotCheckOpened(file, fileFormatName);
+            Boolean status = openProductFileDoNotCheckOpened(file, fileFormatName, dialogAfter);
             if (status == null) {
                 // Cancelled
                 summaryStatus = null;
@@ -327,12 +334,12 @@ public class ProductOpener {
     }
 
 
-    private static Boolean openProductFileDoNotCheckOpened(File file, String formatName) {
+    private static Boolean openProductFileDoNotCheckOpened(File file, String formatName, int dialogAfter) {
         SnapApp.getDefault().setStatusBarMessage(MessageFormat.format("Reading product ''{0}''...", file.getName()));
 
         ReadProductOperation operation = new ReadProductOperation(file, formatName);
         final ProgressHandle progressHandle = ProgressHandleFactory.createHandle("Please wait while the data product is being read...", operation);
-        ProgressUtils.runOffEventThreadWithProgressDialog(operation, "Reading Product", progressHandle, false, 50, 2000);
+        ProgressUtils.runOffEventThreadWithProgressDialog(operation, "Reading Product", progressHandle, false, 50, dialogAfter);
         progressHandle.start();
         progressHandle.switchToIndeterminate();
 


### PR DESCRIPTION
This is a temporary work around for the generic binary readers. Currently, the readers are a UI only implementation which prompt the user for parameters.
This pull request disables the progress dialog by allowing the reader configuration to set the time before the dialog appears. If none is set, then the default 2 secs is used.

This will not be needed once readers and writers can be parameterized like operators but, as I understand it, this will not be implemented any time soon.