### PR TITLE
SNAP-186: show ProductData.UTC properly in the metadata

### DIFF
--- a/snap-ui/src/main/java/org/esa/snap/ui/product/metadata/MetadataElementLeafNode.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/product/metadata/MetadataElementLeafNode.java
@@ -63,6 +63,10 @@ class MetadataElementLeafNode extends AbstractNode {
                 attributePropertyList.add(new IntegerProperty("Value"));
                 break;
             case ProductData.TYPE_UINT32:
+                if(leaf.getData() instanceof ProductData.UTC) {
+                    attributePropertyList.add(new StringProperty("Value"));
+                    break;
+                }
                 attributePropertyList.add(new IntegerProperty("Value"));
                 break;
             case ProductData.TYPE_FLOAT64:

--- a/snap-ui/src/main/java/org/esa/snap/ui/product/metadata/MetadataTableInnerElement.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/product/metadata/MetadataTableInnerElement.java
@@ -57,12 +57,16 @@ public class MetadataTableInnerElement implements MetadataTableElement {
                         addDoubleMetadataAttributes(attribute, (double[]) dataElems, metadataTableElementList);
                     }
                 } else if (ProductData.isIntType(dataType)) {
-                    if(dataElems instanceof byte[]) {
-                        addByteMetadataAttributes(attribute, (byte[]) dataElems, metadataTableElementList);
-                    } else if(dataElems instanceof short[]) {
-                        addShortMetadataAttributes(attribute, (short[]) dataElems, metadataTableElementList);
+                    if(attribute.getData() instanceof ProductData.UTC) {
+                        metadataTableElementList.add(new MetadataTableLeaf(attribute));
                     } else {
-                        addIntMetadataAttributes(attribute, (int[]) dataElems, metadataTableElementList);
+                        if (dataElems instanceof byte[]) {
+                            addByteMetadataAttributes(attribute, (byte[]) dataElems, metadataTableElementList);
+                        } else if (dataElems instanceof short[]) {
+                            addShortMetadataAttributes(attribute, (short[]) dataElems, metadataTableElementList);
+                        } else {
+                            addIntMetadataAttributes(attribute, (int[]) dataElems, metadataTableElementList);
+                        }
                     }
                 } else {
                     metadataTableElementList.add(new MetadataTableLeaf(attribute));


### PR DESCRIPTION
SNAP Metadata view renders ProductData.UTC as three UINT32 instead of the formatted date and time.
This fix will render the UTC in its String format.

The problem arises from a long standing bug where ProductData.UTC are shown as type UINT32 instead of UTC. 