### PR TITLE
Casts values to double - Fix for ticket SNAP-1045

### DIFF
--- a/snap-gpf-ui/src/main/java/org/esa/snap/core/gpf/ui/resample/ResamplingDialog.java
+++ b/snap-gpf-ui/src/main/java/org/esa/snap/core/gpf/ui/resample/ResamplingDialog.java
@@ -417,9 +417,9 @@ class ResamplingDialog extends SingleTargetProductDialog {
 
         private void reactToSourceProductChange(Product product) {
             if (product != null) {
-                resolutionSpinner.setValue(determineResolutionFromProduct(product));
+                resolutionSpinner.setValue(new Double(determineResolutionFromProduct(product)));
             } else {
-                resolutionSpinner.setValue(0);
+                resolutionSpinner.setValue(0.0);
             }
         }
 


### PR DESCRIPTION
This change allows the Resampling dialog to now successfully open and resample imagery, casting values to Double. 