### PR TITLE
SEADAS-001a (PropertyPane: use JScrollPanel instead of JPanel)

### DIFF
--- a/snap-ui/src/main/java/org/esa/snap/ui/layer/AbstractLayerConfigurationEditor.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/layer/AbstractLayerConfigurationEditor.java
@@ -36,6 +36,9 @@ import java.beans.PropertyChangeListener;
  * @version $Revision$ $Date$
  * @since BEAM 4.6
  */
+// SEP2018 - Daniel Knowles - Modified to call a new method propertyPane.createJScrollPanel(), which returns
+// a JScrollPane instead of a JPanel in order to ensure all property components can be accessed by the user
+
 public abstract class AbstractLayerConfigurationEditor extends AbstractLayerEditor {
 
     private BindingContext bindingContext;
@@ -54,7 +57,18 @@ public abstract class AbstractLayerConfigurationEditor extends AbstractLayerEdit
         propertySet.addPropertyChangeListener(new PropertyChangeHandler());
         addEditablePropertyDescriptors();
         PropertyPane propertyPane = new PropertyPane(bindingContext);
-        return propertyPane.createPanel();
+
+        //
+        // Modification note: Daniel Knowles 2018
+        // Modified to return JScrollPane instead of JPanel due to the large number of properties being added to the Graticule layer
+        // If for some reason this option is only desired for a certain layer then the following type of if clause might be used
+        // if ("Graticule".equals(getCurrentLayer().getName())) {
+        //     return propertyPane.createJScrollPanel();
+        // } else {
+        //     return propertyPane.createPanel();
+        // }
+        //
+        return propertyPane.createJScrollPanel();
     }
 
     @Override


### PR DESCRIPTION
This utilizes the JScrollPanel method added to PropertyPane (see recent snap-engine pull request).  The use of this method is important as some of the future tools modifications such as Graticule and Color Bar Layer contain too many parameters to fit in a standard non-scrolling window.