### PR TITLE
SEADAS-006 (RangeFinder tool: revised line size and color)

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/interactors/RangeFinderInteractor.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/interactors/RangeFinderInteractor.java
@@ -292,9 +292,9 @@ class RangeFinderInteractor extends ViewportInteractor {
             }
             Graphics2D g2d = rendering.getGraphics();
             final Stroke strokeOld = g2d.getStroke();
-            g2d.setStroke(new BasicStroke(0.1f));
+            g2d.setStroke(new BasicStroke(1.0f));
             final Color colorOld = g2d.getColor();
-            g2d.setColor(Color.red);
+            g2d.setColor(Color.white);
             g2d.translate(0.5, 0.5);
 
             final int r = 3;


### PR DESCRIPTION
RangeFinder tool: revised line size and color.  The former line size and color made it almost invisible to the user.  Revised the color to white and the size to be bigger.  This will better match other tools (like for instance the Line Drawing tools).