### PR TITLE
SEADAS-001d (PreferenceUtils: ColorComboBox user preference not retained)

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/preferences/PreferenceUtils.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/preferences/PreferenceUtils.java
@@ -17,26 +17,30 @@
 package org.esa.snap.rcp.preferences;
 
 import com.bc.ceres.binding.Property;
+import com.bc.ceres.binding.PropertyDescriptor;
 import com.bc.ceres.binding.ValidationException;
 import com.bc.ceres.swing.TableLayout;
 import org.esa.snap.core.util.SystemUtils;
 import org.openide.awt.ColorComboBox;
 
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSeparator;
+import javax.swing.*;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 
 /**
  * Contains some static helper functions.
  *
  * @author thomas
  */
+// SEP2018 - Daniel Knowles - Fixes bug where colorComboBox was not listening to properties change event when
+// DefaultConfigController was loading the user saved preferences
+
 public class PreferenceUtils {
 
     /**
@@ -113,6 +117,23 @@ public class PreferenceUtils {
             }
         });
         colorComboBox.setPreferredSize(new Dimension(colorComboBox.getWidth(), 25));
+
+        // Modification by Daniel Knowles SEP2018
+        // Add PropertyChangeListener to the passed in property which when triggered sets the colorComboBox selected color.
+        // This fixes bug where colorComboBox was not listening to properties change event when DefaultConfigController was
+        // loading the user saved preferences
+
+        property.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                colorComboBox.setSelectedColor(property.getValue());
+            }
+        });
+
         return colorComboBox;
     }
+
+
+
+
 }


### PR DESCRIPTION
Fixes bug where colorComboBox was not listening to properties change event when DefaultConfigController was loading the user saved preferences.

For example: If user sets the line color within the Graticule layer preferences to green and then closes and reopenes SNAP, the preferences line color of the Graticule layer would be back to the default of white instead of green.

Note: the SEADAS revisions to the graticule tool will not actually call this createColorCombobox method but it is a bug in the current snap master.

