### PR TITLE
SEADAS-010 (Panner Tool: set to be on by default)

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/interactors/PannerToolAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/interactors/PannerToolAction.java
@@ -50,6 +50,7 @@ public class PannerToolAction extends ToolAction {
     public PannerToolAction(Lookup lookup) {
         super(lookup, new PanInteractor());
         putValue(NAME, Bundle.CTL_PannerToolActionText());
+        putValue(SELECTED_KEY, true);   //Set Image Panning Tool as default
         putValue(SHORT_DESCRIPTION, Bundle.CTL_PannerToolActionDescription());
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon("org/esa/snap/rcp/icons/PannerTool24.gif", false));
     }


### PR DESCRIPTION
It is more common for users to want to use the panner tool than to use the select tool, especially when initially opening a file.  This modification sets the panner tool to be on by default.