### PR TITLE
SEADAS 008b: Color Manipulation log scaling bugs fixed

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ColorUtils.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ColorUtils.java
@@ -6,8 +6,16 @@ import org.esa.snap.rcp.SnapApp;
  * Utility class containing methods to the Color Manipulation Tool.
  *
  * @author Jean Coravu
- * @author Daniel Knowles
+ * @author Daniel Knowles (NASA)
  */
+// OCT 2019 - Knowles
+//          - Added methods to perform numerical checks which return a boolean with the additional option to display
+//            the error message in the GUI status bar.
+
+
+
+
+
 public class ColorUtils {
 
     /**

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ColorUtils.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ColorUtils.java
@@ -1,9 +1,12 @@
 package org.esa.snap.rcp.colormanip;
 
+import org.esa.snap.rcp.SnapApp;
+
 /**
- * Utility class containing methods to process the colors.
+ * Utility class containing methods to the Color Manipulation Tool.
  *
  * @author Jean Coravu
+ * @author Daniel Knowles
  */
 public class ColorUtils {
 
@@ -67,5 +70,109 @@ public class ColorUtils {
      */
     public static int blue(int color) {
         return color & 0x0FF;
+    }
+
+    public static boolean isNumber(String string) {
+        try {
+            double d = Double.parseDouble(string);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean isNumber(String string, String componentName, boolean showMessage) {
+        try {
+            double d = Double.parseDouble(string);
+        } catch (NumberFormatException nfe) {
+            if (showMessage) {
+                SnapApp.getDefault().setStatusBarMessage("INPUT ERROR!!: " + componentName + "=" + string + " is not a number");
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+
+    public static boolean checkRangeCompatibility(String minStr, String maxStr) {
+
+        if (!isNumber(minStr, "Min Textfield", true)) {
+            return false;
+        }
+
+        if (!isNumber(maxStr, "Min Textfield", true)) {
+            return false;
+        }
+
+        double min = Double.parseDouble(minStr);
+        double max = Double.parseDouble(maxStr);
+        if (!checkRangeCompatibility(min, max)) {
+            return false;
+        }
+
+        SnapApp.getDefault().setStatusBarMessage("");
+        return true;
+    }
+
+
+
+    public static boolean checkRangeCompatibility(double min, double max) {
+
+        if (min >= max) {
+            SnapApp.getDefault().setStatusBarMessage("INPUT ERROR!!: Max must be greater than Min");
+            return false;
+        }
+
+        SnapApp.getDefault().setStatusBarMessage("");
+        return true;
+    }
+
+
+
+    public static boolean checkRangeCompatibility(double min, double max, boolean isLogScaled) {
+
+        if (!checkRangeCompatibility(min, max)) {
+            return false;
+        }
+
+        if (!checkLogCompatibility(min, "Min Textfield", isLogScaled)) {
+            return false;
+        }
+
+        SnapApp.getDefault().setStatusBarMessage("");
+        return true;
+    }
+
+
+    public static boolean checkSliderRangeCompatibility(double value, double min, double max) {
+        if (value <= min || value >= max) {
+            SnapApp.getDefault().setStatusBarMessage("INPUT ERROR!!: Slider outside range of adjacent sliders");
+            return false;
+        }
+        return true;
+    }
+
+
+
+    public static boolean checkLogCompatibility(double value, String componentName, boolean isLogScaled) {
+
+        if ((isLogScaled) && value <= 0) {
+            SnapApp.getDefault().setStatusBarMessage("INPUT ERROR!!: " + componentName + " must be greater than zero in log scaling mode");
+            return false;
+        }
+
+        SnapApp.getDefault().setStatusBarMessage("");
+
+        return true;
+    }
+
+    public static boolean checkTableRangeCompatibility(double value, double min, double max) {
+        if (value <= min || value >= max) {
+            SnapApp.getDefault().setStatusBarMessage("INPUT ERROR!!: Value outside range of adjacent Table Values");
+            return false;
+        }
+        return true;
     }
 }

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandBasicForm.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandBasicForm.java
@@ -24,11 +24,9 @@ import org.esa.snap.core.datamodel.RasterDataNode;
 import org.esa.snap.core.datamodel.Stx;
 import org.esa.snap.core.util.math.Range;
 
-import javax.swing.AbstractButton;
-import javax.swing.JButton;
-import javax.swing.JFormattedTextField;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.text.NumberFormatter;
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -46,17 +44,26 @@ public class Continuous1BandBasicForm implements ColorManipulationChildForm {
     private final ColorPaletteChooser colorPaletteChooser;
     private final JFormattedTextField minField;
     private final JFormattedTextField maxField;
+    private String currentMinFieldValue = "";
+    private String currentMaxFieldValue = "";
     private final DiscreteCheckBox discreteCheckBox;
 
 
-    private enum RangeKey {FromPaletteSource, FromData, FromMinMaxFields, FromCurrentPalette}
+    final Boolean[] minFieldActivated = {new Boolean(false)};
+    final Boolean[] maxFieldActivated = {new Boolean(false)};
+    final Boolean[] listenToLogDisplayButtonEnabled = {true};
+    final Boolean[] basicSwitcherIsActive;
+
+
+    private enum RangeKey {FromPaletteSource, FromData, FromMinMaxFields, FromCurrentPalette, ToggleLog, InvertPalette, Dummy}
     private boolean shouldFireChooserEvent;
     private boolean hidden = false;
 
-    Continuous1BandBasicForm(final ColorManipulationForm parentForm) {
+    Continuous1BandBasicForm(final ColorManipulationForm parentForm, final Boolean[] basicSwitcherIsActive) {
         ColorPaletteManager.getDefault().loadAvailableColorPalettes(parentForm.getIODir().toFile());
 
         this.parentForm = parentForm;
+        this.basicSwitcherIsActive = basicSwitcherIsActive;
 
         final TableLayout layout = new TableLayout();
         layout.setTableWeightX(1.0);
@@ -100,8 +107,41 @@ public class Continuous1BandBasicForm implements ColorManipulationChildForm {
         shouldFireChooserEvent = true;
 
         colorPaletteChooser.addActionListener(createListener(RangeKey.FromCurrentPalette));
-        minField.addActionListener(createListener(RangeKey.FromMinMaxFields));
-        maxField.addActionListener(createListener(RangeKey.FromMinMaxFields));
+//        minField.addActionListener(createListener(RangeKey.FromMinMaxFields));
+//        maxField.addActionListener(createListener(RangeKey.FromMinMaxFields));
+        maxField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+
+            public void insertUpdate(DocumentEvent documentEvent) {
+                handleMaxTextfield();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent documentEvent) {
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent documentEvent) {
+            }
+        });
+
+        minField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent documentEvent) {
+                handleMinTextfield();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent documentEvent) {
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent documentEvent) {
+            }
+        });
+
+
+
         fromFile.addActionListener(createListener(RangeKey.FromPaletteSource));
         fromData.addActionListener(createListener(RangeKey.FromData));
 
@@ -114,24 +154,36 @@ public class Continuous1BandBasicForm implements ColorManipulationChildForm {
 
         logDisplayButton = LogDisplay.createButton();
         logDisplayButton.addActionListener(e -> {
-            final boolean shouldLog10Display = logDisplayButton.isSelected();
-            final ImageInfo imageInfo = parentForm.getFormModel().getModifiedImageInfo();
-            if (shouldLog10Display) {
-                final ColorPaletteDef cpd = imageInfo.getColorPaletteDef();
-                if (LogDisplay.checkApplicability(cpd)) {
-                    colorPaletteChooser.setLog10Display(true);
-                    imageInfo.setLogScaled(true);
-                    parentForm.applyChanges();
-                } else {
-                    LogDisplay.showNotApplicableInfo(parentForm.getContentPanel());
-                    logDisplayButton.setSelected(false);
-                }
-            } else {
-                colorPaletteChooser.setLog10Display(false);
-                imageInfo.setLogScaled(false);
-                parentForm.applyChanges();
+            if (listenToLogDisplayButtonEnabled[0]) {
+                listenToLogDisplayButtonEnabled[0] = false;
+                logDisplayButton.setSelected(!logDisplayButton.isSelected());
+
+                applyChanges(RangeKey.ToggleLog);
+                listenToLogDisplayButtonEnabled[0] = true;
             }
         });
+    }
+
+    private void handleMaxTextfield() {
+
+        if (!currentMaxFieldValue.equals(maxField.getText().toString())) {
+            if (!maxFieldActivated[0] && !basicSwitcherIsActive[0]) {
+                maxFieldActivated[0] = true;
+                applyChanges(RangeKey.FromMinMaxFields);
+                maxFieldActivated[0] = false;
+            }
+        }
+    }
+
+    private void handleMinTextfield() {
+
+        if (!currentMinFieldValue.equals(minField.getText().toString())) {
+            if (!minFieldActivated[0] && !basicSwitcherIsActive[0]) {
+                minFieldActivated[0] = true;
+                applyChanges(RangeKey.FromMinMaxFields);
+                minFieldActivated[0] = false;
+            }
+        }
     }
 
     @Override
@@ -177,8 +229,17 @@ public class Continuous1BandBasicForm implements ColorManipulationChildForm {
         discreteCheckBox.setDiscreteColorsMode(discrete);
         logDisplayButton.setSelected(logScaled);
         parentForm.revalidateToolViewPaneControl();
-        minField.setValue(cpd.getMinDisplaySample());
-        maxField.setValue(cpd.getMaxDisplaySample());
+        if (!minFieldActivated[0]) {
+            minField.setValue(cpd.getMinDisplaySample());
+            currentMinFieldValue = minField.getText().toString();
+        }
+
+        if (!maxFieldActivated[0]) {
+            maxField.setValue(cpd.getMaxDisplaySample());
+            currentMaxFieldValue = maxField.getText().toString();
+        }
+//        minField.setValue(cpd.getMinDisplaySample());
+//        maxField.setValue(cpd.getMaxDisplaySample());
     }
 
     @Override
@@ -228,6 +289,8 @@ public class Continuous1BandBasicForm implements ColorManipulationChildForm {
 
     private void applyChanges(RangeKey key) {
         if (shouldFireChooserEvent) {
+            boolean checksOut = true;
+
             final ColorPaletteDef selectedCPD = colorPaletteChooser.getSelectedColorPaletteDefinition();
             final ImageInfo currentInfo = parentForm.getFormModel().getModifiedImageInfo();
             final ColorPaletteDef currentCPD = currentInfo.getColorPaletteDef();
@@ -236,33 +299,89 @@ public class Continuous1BandBasicForm implements ColorManipulationChildForm {
 
             final double min;
             final double max;
+            final boolean isSourceLogScaled;
+            final boolean isTargetLogScaled;
             final ColorPaletteDef cpd;
+            final boolean autoDistribute;
+
             switch (key) {
             case FromPaletteSource:
                 final Range rangeFromFile = colorPaletteChooser.getRangeFromFile();
+                isSourceLogScaled = currentInfo.isLogScaled();
+                isTargetLogScaled = currentInfo.isLogScaled();
                 min = rangeFromFile.getMin();
                 max = rangeFromFile.getMax();
                 cpd = currentCPD;
+                autoDistribute = true;
                 break;
             case FromData:
                 final Stx stx = parentForm.getStx(parentForm.getFormModel().getRaster());
+                isSourceLogScaled = currentInfo.isLogScaled();
+                isTargetLogScaled = currentInfo.isLogScaled();
                 min = stx.getMinimum();
                 max = stx.getMaximum();
                 cpd = currentCPD;
+                autoDistribute = true;
                 break;
             case FromMinMaxFields:
-                min = (double) minField.getValue();
-                max = (double) maxField.getValue();
+                isSourceLogScaled = currentInfo.isLogScaled();
+                isTargetLogScaled = currentInfo.isLogScaled();
+//                parentForm.getImageInfo().getColorPaletteSourcesInfo().setAlteredScheme(true);
+
+
+                if (ColorUtils.checkRangeCompatibility(minField.getText().toString(), maxField.getText().toString())) {
+                    min = Double.parseDouble(minField.getText().toString());
+                    max = Double.parseDouble(maxField.getText().toString());
+                } else {
+                    checksOut = false;
+                    min = 0; //bogus unused values set just so it is initialized to make idea happy
+                    max = 0; //bogus unused values set just so it is initialized to make idea happy
+                }
+
                 cpd = currentCPD;
+                autoDistribute = true;
+                break;
+            case ToggleLog:
+                isSourceLogScaled = currentInfo.isLogScaled();
+                isTargetLogScaled = !currentInfo.isLogScaled();
+//                parentForm.getImageInfo().getColorPaletteSourcesInfo().setAlteredScheme(true);
+
+                min = currentCPD.getMinDisplaySample();
+                max = currentCPD.getMaxDisplaySample();
+                cpd = currentCPD;
+
+                autoDistribute = true;
                 break;
             default:
+                isSourceLogScaled = selectedCPD.isLogScaled();
+                isTargetLogScaled = currentInfo.isLogScaled();
                 min = currentCPD.getMinDisplaySample();
                 max = currentCPD.getMaxDisplaySample();
                 cpd = deepCopy;
+                autoDistribute = true;
+
             }
-            final boolean autoDistribute = true;
-            currentInfo.setColorPaletteDef(cpd, min, max, autoDistribute);
-            parentForm.applyChanges();
+
+            if (checksOut && ColorUtils.checkRangeCompatibility(min, max, isTargetLogScaled)) {
+//                if (key == RangeKey.InvertPalette) {
+//                    currentInfo.setColorPaletteDefInvert(cpd);
+//                } else {
+//                    currentInfo.setColorPaletteDef(cpd, min, max, autoDistribute, isSourceLogScaled, isTargetLogScaled);
+//                }
+                currentInfo.setColorPaletteDef(cpd, min, max, autoDistribute, isSourceLogScaled, isTargetLogScaled);
+
+                if (key == RangeKey.ToggleLog) {
+                    currentInfo.setLogScaled(isTargetLogScaled);
+                    colorPaletteChooser.setLog10Display(isTargetLogScaled);
+                }
+                currentMinFieldValue = Double.toString(min);
+                currentMaxFieldValue = Double.toString(max);
+                parentForm.applyChanges();
+            }
         }
     }
+
+
+
+
 }

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandBasicForm.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandBasicForm.java
@@ -35,6 +35,23 @@ import java.awt.Insets;
 import java.awt.event.ActionListener;
 import java.text.DecimalFormat;
 
+/**
+ *
+ * @author Brockmann Consult
+ * @author Daniel Knowles (NASA)
+ * @author Bing Yang (NASA)
+ */
+// OCT 2019 - Knowles / Yang
+//          - Added DocumentListener to minField and maxField to make sure that the values are being updated.
+//            Previously the values would only be updated if the user hit enter and a lose focus event would not
+//            trigger a value update.
+//          - Fixes log scaling bug where the log scaling was not affecting the palette values.  This was achieved
+//            by tracking the source and target log scaling and passing this information to the method
+//            setColorPaletteDef() in the class ImageInfo.
+//          - Added numerical checks on the minField and maxField.
+
+
+
 public class Continuous1BandBasicForm implements ColorManipulationChildForm {
 
     private final ColorManipulationForm parentForm;

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandGraphicalForm.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandGraphicalForm.java
@@ -31,6 +31,20 @@ import javax.swing.JPanel;
 import java.awt.BorderLayout;
 import java.awt.Component;
 
+
+/**
+ *
+ * @author Brockmann Consult
+ * @author Daniel Knowles (NASA)
+ * @author Bing Yang (NASA)
+ */
+// OCT 2019 - Knowles / Yang
+//          - Fixes log scaling bug where the log scaling was not affecting the palette values.  This was achieved
+//            by tracking the source and target log scaling and passing this information to the method
+//            setColorPaletteDef() in the class ImageInfo.
+//          - Set computeZoomInToSliderLimits() to be the default display behavior of the histogram display
+
+
 public class Continuous1BandGraphicalForm implements ColorManipulationChildForm {
 
     public static final Scaling POW10_SCALING = new Pow10Scaling();

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandSwitcherForm.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandSwitcherForm.java
@@ -41,6 +41,7 @@ public class Continuous1BandSwitcherForm implements ColorManipulationChildForm {
     private Continuous1BandTabularForm tabularPaletteEditorForm;
     private JRadioButton basicButton;
     private Continuous1BandBasicForm basicPaletteEditorForm;
+    public Boolean[] basicSwitcherIsActive = {false};
 
     public Continuous1BandSwitcherForm(final ColorManipulationForm parentForm) {
         this.parentForm = parentForm;
@@ -52,7 +53,7 @@ public class Continuous1BandSwitcherForm implements ColorManipulationChildForm {
         editorGroup.add(basicButton);
         editorGroup.add(graphicalButton);
         editorGroup.add(tabularButton);
-        graphicalButton.setSelected(true);
+        basicButton.setSelected(true);
         final SwitcherActionListener switcherActionListener = new SwitcherActionListener();
         basicButton.addActionListener(switcherActionListener);
         graphicalButton.addActionListener(switcherActionListener);
@@ -121,7 +122,7 @@ public class Continuous1BandSwitcherForm implements ColorManipulationChildForm {
             newForm = tabularPaletteEditorForm;
         } else if (basicButton.isSelected()) {
             if (basicPaletteEditorForm == null) {
-                basicPaletteEditorForm = new Continuous1BandBasicForm(parentForm);
+                basicPaletteEditorForm = new Continuous1BandBasicForm(parentForm, basicSwitcherIsActive);
             }
             newForm = basicPaletteEditorForm;
         } else {
@@ -161,7 +162,9 @@ public class Continuous1BandSwitcherForm implements ColorManipulationChildForm {
 
         @Override
         public void actionPerformed(ActionEvent e) {
+            basicSwitcherIsActive[0] = true;
             switchForm();
+            basicSwitcherIsActive[0] = false;
         }
     }
 }

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandSwitcherForm.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandSwitcherForm.java
@@ -30,6 +30,15 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+/**
+ *
+ * @author Brockmann Consult
+ * @author Daniel Knowles (NASA)
+ */
+// OCT 2019 - Knowles
+//          - Set basic mode to be the default
+
+
 public class Continuous1BandSwitcherForm implements ColorManipulationChildForm {
 
     private final ColorManipulationForm parentForm;

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandTabularForm.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/Continuous1BandTabularForm.java
@@ -33,6 +33,18 @@ import javax.swing.table.AbstractTableModel;
 import java.awt.Color;
 import java.awt.Component;
 
+/**
+ *
+ * @author Brockmann Consult
+ * @author Daniel Knowles (NASA)
+ * @author Bing Yang (NASA)
+ */
+// OCT 2019 - Knowles / Yang
+//          - Added checks to ensure that only positive values are allowed in log scaling mode.
+//          - Added checks to ensure that palette values are numeric.
+//          - Added checks to ensure that value entries are numerically between the adjacent values.
+
+
 public class Continuous1BandTabularForm implements ColorManipulationChildForm {
 
     private static final String[] COLUMN_NAMES = new String[]{"Colour", "Value"};

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ImageInfoEditor2.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ImageInfoEditor2.java
@@ -212,4 +212,16 @@ class ImageInfoEditor2 extends ImageInfoEditor {
             UIUtils.setRootFrameDefaultCursor(ImageInfoEditor2.this);
         }
     }
+
+
+    @Override
+    protected boolean checkLogCompatibility(double value, String componentName, boolean isLogScaled) {
+        return ColorUtils.checkLogCompatibility(value, componentName, isLogScaled);
+    }
+
+    @Override
+    protected boolean checkSliderRangeCompatibility(double value, double min, double max) {
+        return ColorUtils.checkSliderRangeCompatibility (value, min, max);
+    }
+
 }

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ImageInfoEditor2.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/colormanip/ImageInfoEditor2.java
@@ -46,6 +46,17 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
 
+/**
+ *
+ * @author Brockmann Consult
+ * @author Daniel Knowles (NASA)
+ * @author Bing Yang (NASA)
+ */
+// OCT 2019 - Knowles / Yang
+//          - Added method to override abstract method "checkSliderRangeCompatibility".
+//          - Added method to override abstract method "checkLogCompatibility".
+
+
 class ImageInfoEditor2 extends ImageInfoEditor {
 
     private final ColorManipulationForm parentForm;

--- a/snap-ui/src/main/java/org/esa/snap/ui/ImageInfoEditor.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/ImageInfoEditor.java
@@ -28,6 +28,7 @@ import org.esa.snap.core.util.math.MathUtils;
 import org.esa.snap.core.util.math.Range;
 import org.esa.snap.ui.color.ColorChooserPanel;
 
+
 import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
 import javax.swing.JMenuItem;
@@ -107,6 +108,8 @@ public abstract class ImageInfoEditor extends JPanel {
     private ModelCL modelCL;
     private JidePopup popup;
     private BufferedImage paletteBackgound;
+
+    private boolean logScaled = false;
 
     public ImageInfoEditor() {
         labelFont = createLabelFont();
@@ -815,11 +818,19 @@ public abstract class ImageInfoEditor extends JPanel {
 
         ctx.addPropertyChangeListener("sample", pce -> {
             hidePopup();
-            setSliderSample(sliderIndex, (Double) ctx.getBinding("sample").getPropertyValue());
-            computeZoomInToSliderLimits();
-            applyChanges();
+            Double value = (Double) ctx.getBinding("sample").getPropertyValue();
+            if (
+                    checkSliderRangeCompatibility(value, valueRange.getMin(), valueRange.getMax())
+                    && checkLogCompatibility(value, "slider", isLogScaled())
+                    ) {
+                setSliderSample(sliderIndex, value);
+                computeZoomInToSliderLimits();
+                applyChanges();
+            }
+
         });
     }
+
 
     private void showPopup(MouseEvent evt, JComponent component) {
         hidePopup();
@@ -838,6 +849,7 @@ public abstract class ImageInfoEditor extends JPanel {
             popup = null;
         }
     }
+
 
     private class InternalMouseListener implements MouseListener, MouseMotionListener {
 
@@ -1179,5 +1191,34 @@ public abstract class ImageInfoEditor extends JPanel {
         public void stateChanged(ChangeEvent e) {
             fireStateChanged();
         }
+    }
+
+
+    /**
+     * Determine whether value is illegal value (zero or less) if in log mode
+     * @param value
+     * @param componentName identify theGUI component
+     * @param isLogScaled
+     * @return
+     */
+    protected abstract boolean checkLogCompatibility(double value, String componentName, boolean isLogScaled);
+
+
+    /**
+     * Determine whether a value is in between a min and a max value
+     * @param value
+     * @param min
+     * @param max
+     * @return
+     */
+    protected abstract boolean checkSliderRangeCompatibility(double value, double min, double max);
+
+
+    public boolean isLogScaled() {
+        return logScaled;
+    }
+
+    public void setLogScaled(boolean logScaled) {
+        this.logScaled = logScaled;
     }
 }

--- a/snap-ui/src/main/java/org/esa/snap/ui/ImageInfoEditor.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/ImageInfoEditor.java
@@ -64,9 +64,18 @@ import java.text.DecimalFormat;
  * Unstable interface. Do not use.
  *
  * @author Norman Fomferra
+ * @author Daniel Knowles (NASA)
+ * @author Bing Yang (NASA)
  * @version $Revision$ $Date$
  * @since BEAM 4.5.1
  */
+// OCT 2019 - Knowles / Yang
+//          - Added a boolean field "logScaled" for determining if log scaled.
+//          - Added abstract method "checkSliderRangeCompatibility" to be used for slider value adjacency checks.
+//          - Added abstract method "checkLogCompatibility" to be used for log scaling illegal value checks.
+//          - Incorporated the above checks within the listener of the slider.
+
+
 public abstract class ImageInfoEditor extends JPanel {
 
     public static final String PROPERTY_NAME_MODEL = "model";
@@ -1205,7 +1214,7 @@ public abstract class ImageInfoEditor extends JPanel {
 
 
     /**
-     * Determine whether a value is in between a min and a max value
+     * Determine whether a value is in between a min and a max value (or adjacent values)
      * @param value
      * @param min
      * @param max


### PR DESCRIPTION
NOTE: this comment and pull request involves edits to both snap-desktop and snap-engine

Color Manipulation Tool: Fixed many bugs all of which are associated with log scaling.

The modifications include:
1. When the log button is selected the sliders and palette values become log scaled retaining any original weighting factors of the pre-log scale conversion.  When the log button is deselected everything restores back to the linear scaling via another math operation.  Previously only the image itself was affected by log scaling.
2. If a user enters a zero for any palette data value when log scaled the GUI will not update with this illegal value but will show an error message in the status bar at the bottom of the GUI.
3. If a user enters a value to a slider or table row that is not in-between the adjacent fields the GUI will not update with this illegal value but an error message in the status bar at the bottom of the GUI.
4. If a user enters a non-numeric palette data value the GUI will not update with this illegal value but an error message in the status bar at the bottom of the GUI.
5. If a user enters a min value greater than or equal to the max value the GUI will not update with this illegal value but an error message in the status bar at the bottom of the GUI.
6. The min and max value fields of the basic mode tab now use a documentListener to make sure that the values are being updated.  Previously the values would only be updated if the user hit enter and a lose focus event would not trigger a value update.
7. The default mode has been set to basic mode instead of slider mode as that mode shows the full details of palette schemes.  Although this is not actually a bug it is a highly desired default and it is a simple single line edit.
NOTE: log scaling bugs not yet fixed:
1. The cpd file reader/writer needs to include a isLogScaled boolean.  Currently the file is treated as linear.  This bug will be addressed in a later pull request.