### PR TITLE
Fix for SNAP-1276

### DIFF
--- a/snap-ui/src/main/java/org/esa/snap/ui/product/ProductSceneView.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/product/ProductSceneView.java
@@ -1187,6 +1187,8 @@ public class ProductSceneView extends BasicView
         private void deriveRasterPropertiesFromExpression(String expression, Product... products) {
             if (products != null) {
                 try {
+                    String validMaskExpression = BandArithmetic.getValidMaskExpression(getExpression(), products, 0, null);
+                    setValidPixelExpression(validMaskExpression);
                     final RasterDataNode[] refRasters = BandArithmetic.getRefRasters(expression, products);
                     if (refRasters.length > 0) {
                         setGeoCoding(refRasters[0].getGeoCoding());


### PR DESCRIPTION
RGB view is wrongly created when using product prefix