### PR TITLE
Help pages: wrong link to Plugins.html in 8.x

### DIFF
--- a/snap-help/src/main/resources/org/esa/snap/snap/help/docs/map.jhm
+++ b/snap-help/src/main/resources/org/esa/snap/snap/help/docs/map.jhm
@@ -20,13 +20,13 @@
     <mapID target="envisatProducts" url="general/envisat-products/index.html"/>
 
     <!-- Target IDs can be found when putting a breakpoint at L506 in class org.netbeans.modules.autoupdate.ui.PluginManagerUI -->
-    <mapID target="org.netbeans.modules.autoupdate.ui.SettingsTab" url="desktop/plugins.html"/>
-    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.UPDATE" url="desktop/plugins.html"/>
-    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.AVAILABLE" url="desktop/plugins.html"/>
-    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.LOCAL" url="desktop/plugins.html"/>
-    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.INSTALLED" url="desktop/plugins.html"/>
+    <mapID target="org.netbeans.modules.autoupdate.ui.SettingsTab" url="desktop/Plugins.html"/>
+    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.UPDATE" url="desktop/Plugins.html"/>
+    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.AVAILABLE" url="desktop/Plugins.html"/>
+    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.LOCAL" url="desktop/Plugins.html"/>
+    <mapID target="org.netbeans.modules.autoupdate.ui.UnitTab.INSTALLED" url="desktop/Plugins.html"/>
 
-    <mapID target="plugins" url="desktop/plugins.html"/>
+    <mapID target="plugins" url="desktop/Plugins.html"/>
 
     <mapID target="gpf.option.controller" url="desktop/Gpf.html"/>
 


### PR DESCRIPTION
Help pages: changed wrongly named help link in the map.jhm file from "plugins.html" to "Plugins.html"

Note: these help files are case-sensitive.