### PR TITLE
SEADAS: vector import menu disabled fix (9.x)

### DIFF
--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportTrackAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportTrackAction.java
@@ -106,7 +106,7 @@ import static org.esa.snap.rcp.SnapApp.SelectionSourceHint.AUTO;
 public class ImportTrackAction extends AbstractSnapAction implements ContextAwareAction, LookupListener {
 
     private Lookup lookup;
-    private final Lookup.Result<Product> result;
+    private final Lookup.Result<ProductNode> result;
 
     public ImportTrackAction() {
         this(Utilities.actionsGlobalContext());
@@ -114,7 +114,7 @@ public class ImportTrackAction extends AbstractSnapAction implements ContextAwar
 
     public ImportTrackAction(Lookup lookup) {
         this.lookup = lookup;
-        result = lookup.lookupResult(Product.class);
+        result = lookup.lookupResult(ProductNode.class);
         result.addLookupListener(
                 WeakListeners.create(LookupListener.class, this, result));
         setEnableState();
@@ -193,7 +193,7 @@ public class ImportTrackAction extends AbstractSnapAction implements ContextAwar
         while ((record = csvReader.readDoubleRecord()) != null) {
             if (record.length < 3) {
                 throw new IOException("Illegal track file format.\n" +
-                                              "Expecting tab-separated lines containing 3 values: lat, lon, data.");
+                        "Expecting tab-separated lines containing 3 values: lat, lon, data.");
             }
 
             float lat = (float) record[0];

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportTrackAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportTrackAction.java
@@ -193,7 +193,7 @@ public class ImportTrackAction extends AbstractSnapAction implements ContextAwar
         while ((record = csvReader.readDoubleRecord()) != null) {
             if (record.length < 3) {
                 throw new IOException("Illegal track file format.\n" +
-                        "Expecting tab-separated lines containing 3 values: lat, lon, data.");
+                                              "Expecting tab-separated lines containing 3 values: lat, lon, data.");
             }
 
             float lat = (float) record[0];

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromCsvAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromCsvAction.java
@@ -100,8 +100,8 @@ public class ImportVectorDataNodeFromCsvAction extends AbstractImportVectorDataN
     @Override
     public void actionPerformed(ActionEvent e) {
         final SnapFileFilter filter = new SnapFileFilter(getVectorDataType(),
-                new String[]{".txt", ".dat", ".csv"},
-                "Plain text");
+                                                         new String[]{".txt", ".dat", ".csv"},
+                                                         "Plain text");
         importer = new VectorDataNodeImporter(getHelpId(), filter, new DefaultVectorDataNodeReader(), "Import CSV file", "csv.io.dir");
         importer.importGeometry(SnapApp.getDefault());
     }
@@ -125,7 +125,7 @@ public class ImportVectorDataNodeFromCsvAction extends AbstractImportVectorDataN
                 CoordinateReferenceSystem modelCrs = product.getSceneCRS();
                 reader = new FileReader(file);
                 return VectorDataNodeReader.read(file.getName(), reader, product, crsProvider, placemarkDescriptorProvider,
-                        modelCrs, VectorDataNodeIO.DEFAULT_DELIMITER_CHAR, pm);
+                                                 modelCrs, VectorDataNodeIO.DEFAULT_DELIMITER_CHAR, pm);
             } finally {
                 if (reader != null) {
                     reader.close();

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromCsvAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromCsvAction.java
@@ -58,7 +58,7 @@ public class ImportVectorDataNodeFromCsvAction extends AbstractImportVectorDataN
         implements ContextAwareAction, LookupListener {
 
     private Lookup lookup;
-    private final Lookup.Result<Product> result;
+    private final Lookup.Result<ProductNode> result;
     private VectorDataNodeImporter importer;
     private static final String vector_data_type = "CSV";
 
@@ -68,7 +68,7 @@ public class ImportVectorDataNodeFromCsvAction extends AbstractImportVectorDataN
 
     public ImportVectorDataNodeFromCsvAction(Lookup lookup) {
         this.lookup = lookup;
-        result = lookup.lookupResult(Product.class);
+        result = lookup.lookupResult(ProductNode.class);
         result.addLookupListener(
                 WeakListeners.create(LookupListener.class, this, result));
         setEnableState();
@@ -100,8 +100,8 @@ public class ImportVectorDataNodeFromCsvAction extends AbstractImportVectorDataN
     @Override
     public void actionPerformed(ActionEvent e) {
         final SnapFileFilter filter = new SnapFileFilter(getVectorDataType(),
-                                                         new String[]{".txt", ".dat", ".csv"},
-                                                         "Plain text");
+                new String[]{".txt", ".dat", ".csv"},
+                "Plain text");
         importer = new VectorDataNodeImporter(getHelpId(), filter, new DefaultVectorDataNodeReader(), "Import CSV file", "csv.io.dir");
         importer.importGeometry(SnapApp.getDefault());
     }
@@ -125,7 +125,7 @@ public class ImportVectorDataNodeFromCsvAction extends AbstractImportVectorDataN
                 CoordinateReferenceSystem modelCrs = product.getSceneCRS();
                 reader = new FileReader(file);
                 return VectorDataNodeReader.read(file.getName(), reader, product, crsProvider, placemarkDescriptorProvider,
-                                                 modelCrs, VectorDataNodeIO.DEFAULT_DELIMITER_CHAR, pm);
+                        modelCrs, VectorDataNodeIO.DEFAULT_DELIMITER_CHAR, pm);
             } finally {
                 if (reader != null) {
                     reader.close();

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromMermaidAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromMermaidAction.java
@@ -56,7 +56,7 @@ import java.io.IOException;
 public class ImportVectorDataNodeFromMermaidAction extends AbstractImportVectorDataNodeAction implements ContextAwareAction, LookupListener {
 
     private Lookup lookup;
-    private final Lookup.Result<Product> result;
+    private final Lookup.Result<ProductNode> result;
     private VectorDataNodeImporter importer;
     private static final String vector_data_type = "CSV";
 
@@ -66,7 +66,7 @@ public class ImportVectorDataNodeFromMermaidAction extends AbstractImportVectorD
 
     public ImportVectorDataNodeFromMermaidAction(Lookup lookup) {
         this.lookup = lookup;
-        result = lookup.lookupResult(Product.class);
+        result = lookup.lookupResult(ProductNode.class);
         result.addLookupListener(
                 WeakListeners.create(LookupListener.class, this, result));
         setEnableState();
@@ -98,8 +98,8 @@ public class ImportVectorDataNodeFromMermaidAction extends AbstractImportVectorD
     @Override
     public void actionPerformed(ActionEvent event) {
         final SnapFileFilter filter = new SnapFileFilter(getVectorDataType(),
-                                                         new String[]{".txt", ".dat", ".csv"},
-                                                         "Plain text");
+                new String[]{".txt", ".dat", ".csv"},
+                "Plain text");
         importer = new VectorDataNodeImporter(getHelpId(), filter, new MermaidReader(), "Import MERMAID Extraction File", "csv.io.dir");
         importer.importGeometry(SnapApp.getDefault());
     }
@@ -125,7 +125,7 @@ public class ImportVectorDataNodeFromMermaidAction extends AbstractImportVectorD
 
                 char delimiterChar = ';';
                 return VectorDataNodeReader.read(file.getName(), reader, product, crsProvider, placemarkDescriptorProvider,
-                                                 modelCrs, delimiterChar, pm);
+                        modelCrs, delimiterChar, pm);
             } finally {
                 if (reader != null) {
                     reader.close();

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromMermaidAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromMermaidAction.java
@@ -98,8 +98,8 @@ public class ImportVectorDataNodeFromMermaidAction extends AbstractImportVectorD
     @Override
     public void actionPerformed(ActionEvent event) {
         final SnapFileFilter filter = new SnapFileFilter(getVectorDataType(),
-                new String[]{".txt", ".dat", ".csv"},
-                "Plain text");
+                                                         new String[]{".txt", ".dat", ".csv"},
+                                                         "Plain text");
         importer = new VectorDataNodeImporter(getHelpId(), filter, new MermaidReader(), "Import MERMAID Extraction File", "csv.io.dir");
         importer.importGeometry(SnapApp.getDefault());
     }
@@ -125,7 +125,7 @@ public class ImportVectorDataNodeFromMermaidAction extends AbstractImportVectorD
 
                 char delimiterChar = ';';
                 return VectorDataNodeReader.read(file.getName(), reader, product, crsProvider, placemarkDescriptorProvider,
-                        modelCrs, delimiterChar, pm);
+                                                 modelCrs, delimiterChar, pm);
             } finally {
                 if (reader != null) {
                     reader.close();

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromShapefileAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromShapefileAction.java
@@ -60,7 +60,7 @@ public class ImportVectorDataNodeFromShapefileAction extends AbstractImportVecto
 
     private VectorDataNodeImporter importer;
     private Lookup lookup;
-    private final Lookup.Result<Product> result;
+    private final Lookup.Result<ProductNode> result;
     private static final String vector_data_type = "SHAPEFILE";
 
     public ImportVectorDataNodeFromShapefileAction() {
@@ -69,7 +69,7 @@ public class ImportVectorDataNodeFromShapefileAction extends AbstractImportVecto
 
     public ImportVectorDataNodeFromShapefileAction(Lookup lookup) {
         this.lookup = lookup;
-        result = lookup.lookupResult(Product.class);
+        result = lookup.lookupResult(ProductNode.class);
         result.addLookupListener(
                 WeakListeners.create(LookupListener.class, this, result));
         setEnableState();
@@ -101,8 +101,8 @@ public class ImportVectorDataNodeFromShapefileAction extends AbstractImportVecto
     @Override
     public void actionPerformed(ActionEvent event) {
         final SnapFileFilter filter = new SnapFileFilter(getVectorDataType(),
-                                                         new String[]{".shp"},
-                                                         "ESRI Shapefiles");
+                new String[]{".shp"},
+                "ESRI Shapefiles");
         importer = new VectorDataNodeImporter(getHelpId(), filter, new VdnShapefileReader(), "Import Shapefile", "shape.io.dir");
         importer.importGeometry(SnapApp.getDefault());
     }
@@ -123,13 +123,13 @@ public class ImportVectorDataNodeFromShapefileAction extends AbstractImportVecto
         public VectorDataNode readVectorDataNode(File file, Product product, ProgressMonitor pm) throws IOException {
 
             DefaultFeatureCollection featureCollection = FeatureUtils.loadShapefileForProduct(file,
-                                                                                              product,
-                                                                                              crsProvider,
-                                                                                              pm);
+                    product,
+                    crsProvider,
+                    pm);
             Style[] styles = SLDUtils.loadSLD(file);
             ProductNodeGroup<VectorDataNode> vectorDataGroup = product.getVectorDataGroup();
             String name = VectorDataNodeImporter.findUniqueVectorDataNodeName(featureCollection.getSchema().getName().getLocalPart(),
-                                                                              vectorDataGroup);
+                    vectorDataGroup);
             if (styles.length > 0) {
                 SimpleFeatureType featureType = SLDUtils.createStyledFeatureType(featureCollection.getSchema());
 

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromShapefileAction.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/actions/vector/ImportVectorDataNodeFromShapefileAction.java
@@ -101,8 +101,8 @@ public class ImportVectorDataNodeFromShapefileAction extends AbstractImportVecto
     @Override
     public void actionPerformed(ActionEvent event) {
         final SnapFileFilter filter = new SnapFileFilter(getVectorDataType(),
-                new String[]{".shp"},
-                "ESRI Shapefiles");
+                                                         new String[]{".shp"},
+                                                         "ESRI Shapefiles");
         importer = new VectorDataNodeImporter(getHelpId(), filter, new VdnShapefileReader(), "Import Shapefile", "shape.io.dir");
         importer.importGeometry(SnapApp.getDefault());
     }
@@ -123,13 +123,13 @@ public class ImportVectorDataNodeFromShapefileAction extends AbstractImportVecto
         public VectorDataNode readVectorDataNode(File file, Product product, ProgressMonitor pm) throws IOException {
 
             DefaultFeatureCollection featureCollection = FeatureUtils.loadShapefileForProduct(file,
-                    product,
-                    crsProvider,
-                    pm);
+                                                                                              product,
+                                                                                              crsProvider,
+                                                                                              pm);
             Style[] styles = SLDUtils.loadSLD(file);
             ProductNodeGroup<VectorDataNode> vectorDataGroup = product.getVectorDataGroup();
             String name = VectorDataNodeImporter.findUniqueVectorDataNodeName(featureCollection.getSchema().getName().getLocalPart(),
-                    vectorDataGroup);
+                                                                              vectorDataGroup);
             if (styles.length > 0) {
                 SimpleFeatureType featureType = SLDUtils.createStyledFeatureType(featureCollection.getSchema());
 


### PR DESCRIPTION
Fixes issue where for some platforms some of the vector import tools are disabled in the Menu.