### PR TITLE
Disable mvn-no-snapshot-deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ include:
 # variables
 variables:
   MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.6.3-jdk-8"
-
+  MVN_FORBID_SNAPSHOT_DEPENDENCIES_DISABLED: "true"
 
 # your pipeline stages
 stages:


### PR DESCRIPTION
Disable a rule set by default by to-be-continuous team forbidding if a project has snapshot dependencies