### PR TITLE
Fixes an issue where some tool windows fail to display on Mac

### DIFF
--- a/snap-ui/src/main/java/org/esa/snap/ui/tool/ToolButtonFactory.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/tool/ToolButtonFactory.java
@@ -15,11 +15,17 @@
  */
 package org.esa.snap.ui.tool;
 
-import com.jidesoft.swing.JideButton;
-import com.jidesoft.swing.JideToggleButton;
 import org.esa.snap.ui.UIUtils;
 
-import javax.swing.*;
+import javax.swing.AbstractButton;
+import javax.swing.Action;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JToggleButton;
+import javax.swing.UIManager;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Image;
@@ -32,10 +38,9 @@ import java.awt.image.FilteredImageSource;
 import java.awt.image.RGBImageFilter;
 import java.util.EventObject;
 
-//import UIUtils;
 
 /**
- * The <code>ToolButtonFactory</code> can be used to create tool bar buttons which have a consistent look and feel.
+ * The {@code ToolButtonFactory} can be used to create tool bar buttons which have a consistent look and feel.
  *
  * @author Norman Fomferra
  * @version $Revision$  $Date$
@@ -66,12 +71,9 @@ public class ToolButtonFactory {
 
     private static AbstractButton createButton(boolean toggle) {
         if (toggle) {
-            JToggleButton button= new JToggleButton();
-            return button;
+            return new JToggleButton();
         } else {
-            JButton button;
-            button = new JButton();
-            return button;
+            return new JButton();
         }
     }
 

--- a/snap-ui/src/main/java/org/esa/snap/ui/tool/ToolButtonFactory.java
+++ b/snap-ui/src/main/java/org/esa/snap/ui/tool/ToolButtonFactory.java
@@ -19,13 +19,7 @@ import com.jidesoft.swing.JideButton;
 import com.jidesoft.swing.JideToggleButton;
 import org.esa.snap.ui.UIUtils;
 
-import javax.swing.AbstractButton;
-import javax.swing.Action;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.UIManager;
+import javax.swing.*;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Image;
@@ -71,13 +65,14 @@ public class ToolButtonFactory {
     }
 
     private static AbstractButton createButton(boolean toggle) {
-        JideButton button;
         if (toggle) {
-            button = new JideToggleButton(); // <JIDE/>
+            JToggleButton button= new JToggleButton();
+            return button;
         } else {
-            button = new JideButton(); // <JIDE/>
+            JButton button;
+            button = new JButton();
+            return button;
         }
-        return button;
     }
 
     private static void configure(AbstractButton button) {


### PR DESCRIPTION
Changed from JIDE button to Jbutton to fix issue where many tool windows fail to display on MacOS Ventura.  We are using OpenJDK11 so this could be unique to OpenJDK as we haven't tested for this bug with Oracle JAVA11