### PR TITLE
Changing the default look and feel to FlatLaf Light on Windows

### DIFF
--- a/snap-rcp/pom.xml
+++ b/snap-rcp/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.esa.snap</groupId>
@@ -56,8 +56,8 @@
                         <publicPackage>org.esa.snap.rcp.about</publicPackage>
                         <publicPackage>org.esa.snap.rcp.actions.*</publicPackage>
                         <publicPackage>org.esa.snap.rcp.util.*</publicPackage>
-						<publicPackage>org.jfree.*</publicPackage>
-						<publicPackage>eu.esa.snap.netbeans.*</publicPackage>
+                        <publicPackage>org.jfree.*</publicPackage>
+                        <publicPackage>eu.esa.snap.netbeans.*</publicPackage>
                     </publicPackages>
                 </configuration>
             </plugin>
@@ -183,6 +183,11 @@
             <artifactId>org-openide-util-ui</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-libs-flatlaf</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.netbeans.modules</groupId>
             <artifactId>org-netbeans-core-startup</artifactId>
             <version>${netbeans.version}</version>
@@ -265,7 +270,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>snap-gpf</artifactId>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.jfree</groupId>
             <artifactId>jfreechart</artifactId>
         </dependency>
@@ -290,12 +295,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-			<scope>test</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-			<scope>test</scope>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/SnapApp.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/SnapApp.java
@@ -4,6 +4,7 @@ import com.bc.ceres.core.ExtensionFactory;
 import com.bc.ceres.core.ExtensionManager;
 import com.bc.ceres.core.ProgressMonitor;
 import com.bc.ceres.swing.progress.ProgressMonitorSwingWorker;
+import com.formdev.flatlaf.FlatLightLaf;
 import eu.esa.snap.netbeans.docwin.DocumentWindowManager;
 import org.esa.snap.core.dataio.ProductReader;
 import org.esa.snap.core.datamodel.*;
@@ -346,6 +347,8 @@ public class SnapApp {
     public void onStart() {
         engine = Engine.start(false);
 
+        initialiseLookAndFeel();
+
         String toolbarConfig = "Standard";
         if (Config.instance().debug()) {
             WindowManager.getDefault().setRole("developer");
@@ -539,6 +542,26 @@ public class SnapApp {
         public void run() {
             LOG.info("Stopping SNAP Desktop");
             SnapApp.getDefault().onStop();
+        }
+    }
+
+    /**
+     * The method changes the default look and feel to FlatLaf Light on Windows, if the user has not changed the look and feel before.
+     * Because of two reasons. First, it looks nicer, and second but more important, it fixes a bug in the Windows look and feel.
+     * The bug is that icons disappear in the Analysis menu when one of the items clicked. It occurs in SNAP 10 with JDK11 and Netbeans 11.3.
+     */
+    private static void initialiseLookAndFeel() {
+        if (Utilities.isWindows()) {
+            Preferences lafPreference = NbPreferences.root().node("laf");
+            if (lafPreference == null || lafPreference.get("laf", null) == null) {
+                try {
+                    UIManager.setLookAndFeel(FlatLightLaf.class.getName());
+                    lafPreference.put("laf", FlatLightLaf.class.getName());
+                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
+                         UnsupportedLookAndFeelException e) {
+                    LOG.warning("Could not set FlatLaf Light Look and Feel");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Changing the default look and feel to FlatLaf Light on Windows, if the user has not changed the look and feel before. Because of two reasons. First, it looks nicer, and second but more important, it fixes a bug in the Windows look and feel. The bug is that icons disappear in the Analysis menu when one of the items clicked. It occurs in SNAP 10 (from IDE) with JDK11 and NetBeans 11.3.
