### PR TITLE
SEADAS: Spectrum View Modifications and Bug Fixes

### DIFF
--- a/snap-help/src/main/resources/org/esa/snap/snap/help/docs/desktop/SpectrumWindow.html
+++ b/snap-help/src/main/resources/org/esa/snap/snap/help/docs/desktop/SpectrumWindow.html
@@ -147,6 +147,31 @@
     </tr>
 </table>
 
+
+<br>
+<h4>Plot Range Fields</h4>
+<pre>
+
+&#8227; Set Bounds X-Axis:
+        Sets bounds of x-axis (uses X-Axis Min and X-Axis Max)
+
+&#8227; X-Axis Min:
+        Sets minimum bound of x-axis (blank entry uses auto-bounding to data)
+
+&#8227; X-Axis Max:
+        Sets maximum bound of x-axis (blank entry uses auto-bounding to data)
+
+&#8227; Set Bounds Y-Axis:
+        Sets bounds of y-axis (uses Y-Axis Min and Y-Axis Max)
+
+&#8227; Y-Axis Min:
+        Sets minimum bound of y-axis (blank entry uses auto-bounding to data)
+
+&#8227; Y-Axis Max:
+        Sets maximum bound of y-axis (blank entry uses auto-bounding to data)
+
+</pre>
+
 <hr>
 </body>
 </html>

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/preferences/general/SpectrumViewController.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/preferences/general/SpectrumViewController.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2011 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+package org.esa.snap.rcp.preferences.general;
+
+import com.bc.ceres.binding.Property;
+import com.bc.ceres.binding.PropertyDescriptor;
+import com.bc.ceres.binding.PropertySet;
+import com.bc.ceres.binding.ValidationException;
+import com.bc.ceres.swing.TableLayout;
+import com.bc.ceres.swing.binding.BindingContext;
+import com.bc.ceres.swing.binding.Enablement;
+import com.bc.ceres.swing.binding.PropertyEditorRegistry;
+import com.bc.ceres.swing.binding.PropertyPane;
+import org.checkerframework.checker.units.qual.C;
+import org.esa.snap.core.util.PropertyMap;
+import org.esa.snap.core.util.StringUtils;
+import org.esa.snap.rcp.SnapApp;
+import org.esa.snap.rcp.preferences.DefaultConfigController;
+import org.esa.snap.rcp.preferences.Preference;
+import org.esa.snap.rcp.statistics.StatisticsTopComponent;
+import org.netbeans.spi.options.OptionsPanelController;
+import org.openide.util.HelpCtx;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Panel handling general preferences for Spectrum View.
+ *
+ * @author Daniel Knowles (NASA)
+ */
+@org.openide.util.NbBundle.Messages({
+        "Options_DisplayName_SpectrumView=" + "Spectrum View",
+        "Options_Keywords_SpectrumView=Spectrum View, general"
+})
+@OptionsPanelController.SubRegistration(location = "GeneralPreferences",
+        displayName = "#Options_DisplayName_SpectrumView",
+        keywords = "#Options_Keywords_SpectrumView",
+        keywordsCategory = "Spectrum, spectral",
+        id = "spectrumViewController",
+        position = 10)
+
+
+public final class SpectrumViewController extends DefaultConfigController {
+
+
+    Property restoreDefaults;
+
+    boolean propertyValueChangeEventsEnabled = true;
+
+    private static final String PROPERTY_ROOT_KEY = "spectrum.view";
+
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_KEY = PROPERTY_ROOT_KEY + ".xaxis.set.bounds";
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_LABEL = "Set Bounds X-Axis";
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_TOOLTIP = "Sets bounds of x-axis (uses X-Axis Min and X-Axis Max)";
+    public static boolean PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_DEFAULT = false;
+    
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_KEY = PROPERTY_ROOT_KEY + ".xaxis.min";
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_LABEL = "X-Axis Min";
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_TOOLTIP = "Sets minimum bound of x-axis (blank entry uses auto-bounding to data)";
+    public static String PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_DEFAULT = "";
+
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_KEY = PROPERTY_ROOT_KEY + ".xaxis.max";
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_LABEL = "X-Axis Max";
+    public static final String PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_TOOLTIP = "Sets maximum bound of x-axis (blank entry uses auto-bounding to data)";
+    public static String PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_DEFAULT = "";
+
+
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_KEY = PROPERTY_ROOT_KEY + ".yaxis.set.bounds";
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_LABEL = "Set Bounds Y-Axis";
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_TOOLTIP = "Sets bounds of y-axis (uses Y-Axis Min and Y-Axis Max)";
+    public static boolean PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_DEFAULT = false;
+    
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_KEY = PROPERTY_ROOT_KEY + ".yaxis.min";
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_LABEL = "Y-Axis Min";
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_TOOLTIP = "Sets minimum bound of x-axis (blank entry uses auto-bounding to data)";
+    public static String PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_DEFAULT = "";
+
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_KEY = PROPERTY_ROOT_KEY + ".yaxis.max";
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_LABEL = "Y-Axis Max";
+    public static final String PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_TOOLTIP = "Sets maximum bound of x-axis (blank entry uses auto-bounding to data)";
+    public static String PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_DEFAULT = "";
+
+    public static final String PROPERTY_SPECTRUM_VIEW_TITLE_KEY = PROPERTY_ROOT_KEY + ".plot.title";
+    public static final String PROPERTY_SPECTRUM_VIEW_TITLE_LABEL = "Plot Title";
+    public static final String PROPERTY_SPECTRUM_VIEW_TITLE_TOOLTIP = "Sets title of plot";
+    public static String PROPERTY_SPECTRUM_VIEW_TITLE_DEFAULT = "Spectrum Plot";
+
+
+//    public static final String PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_KEY = PROPERTY_ROOT_KEY + ".foreground.color";
+//    public static final String PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_LABEL = "Foreground Color";
+//    public static final String PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_TOOLTIP = "Sets foreground color of the plot";
+    public static Color PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_DEFAULT = Color.BLACK;
+
+    public static final String PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_KEY = PROPERTY_ROOT_KEY + "plot.background.color";
+    public static final String PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_LABEL = "Plot Background Color";
+    public static final String PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_TOOLTIP = "Sets background color of the plot";
+    public static Color PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_DEFAULT = Color.WHITE;
+
+//    public static final String PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_KEY = PROPERTY_ROOT_KEY + ".margin.background.color";
+//    public static final String PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_LABEL = "Margin Background Color";
+//    public static final String PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_TOOLTIP = "Sets background color of the margin";
+    public static Color PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_DEFAULT = Color.WHITE;
+
+//    public static final String PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_KEY = PROPERTY_ROOT_KEY + ".legend.background.color";
+//    public static final String PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_LABEL = "Legend Background Color";
+//    public static final String PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_TOOLTIP = "Sets background color of the legend";
+    public static Color PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_DEFAULT = Color.WHITE;
+
+    
+    public static final String PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_KEY = PROPERTY_ROOT_KEY + ".gridlines.color";
+    public static final String PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_LABEL = "Plot Gridlines Color";
+    public static final String PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_TOOLTIP = "Sets color of the plot gridlines";
+    public static Color PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_DEFAULT = Color.LIGHT_GRAY;
+
+    public static final String PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_KEY = PROPERTY_ROOT_KEY + ".gridlines.show";
+    public static final String PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_LABEL = "Show Gridlines";
+    public static final String PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_TOOLTIP = "show plot gridlines";
+    public static boolean PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_DEFAULT = true;
+
+    // Restore to defaults
+
+
+    private static final String PROPERTY_RESTORE_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".restore.defaults";
+
+    public static final String PROPERTY_RESTORE_SECTION_KEY = PROPERTY_RESTORE_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_RESTORE_SECTION_LABEL = "Restore";
+    public static final String PROPERTY_RESTORE_SECTION_TOOLTIP = "Restores preferences to the package defaults";
+
+    public static final String PROPERTY_RESTORE_DEFAULTS_NAME = PROPERTY_RESTORE_KEY_SUFFIX + ".apply";
+    public static final String PROPERTY_RESTORE_DEFAULTS_LABEL = "Restore Defaults (Spectrum View Preferences)";
+    public static final String PROPERTY_RESTORE_DEFAULTS_TOOLTIP = "Restore all RGB Image preferences to the original default";
+    public static final boolean PROPERTY_RESTORE_DEFAULTS_DEFAULT = false;
+
+
+
+
+    protected PropertySet createPropertySet() {
+        return createPropertySet(new GeneralLayerBean());
+    }
+
+
+    @Override
+    public HelpCtx getHelpCtx() {
+        return new HelpCtx("colorManipulationPreferences");
+    }
+
+    @Override
+    protected JPanel createPanel(BindingContext context) {
+
+
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_KEY, PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_KEY, PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_KEY, PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_DEFAULT);
+
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_KEY, PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_KEY, PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_KEY, PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_DEFAULT);
+        
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_TITLE_KEY, PROPERTY_SPECTRUM_VIEW_TITLE_DEFAULT);
+
+//        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_DEFAULT);
+//        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_DEFAULT);
+//        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_DEFAULT);
+        initPropertyDefaults(context, PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_KEY, PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_DEFAULT);
+
+        
+        restoreDefaults =  initPropertyDefaults(context, PROPERTY_RESTORE_DEFAULTS_NAME, PROPERTY_RESTORE_DEFAULTS_DEFAULT);
+
+
+
+
+        //
+        // Create UI
+        //
+
+        TableLayout tableLayout = new TableLayout(2);
+        tableLayout.setTableAnchor(TableLayout.Anchor.NORTHWEST);
+        tableLayout.setTablePadding(new Insets(4, 10, 0, 0));
+        tableLayout.setTableFill(TableLayout.Fill.BOTH);
+        tableLayout.setColumnWeightX(1, 1.0);
+
+        JPanel pageUI = new JPanel(tableLayout);
+
+        PropertyEditorRegistry registry = PropertyEditorRegistry.getInstance();
+
+        PropertySet propertyContainer = context.getPropertySet();
+        Property[] properties = propertyContainer.getProperties();
+
+        int currRow = 0;
+        for (Property property : properties) {
+            PropertyDescriptor descriptor = property.getDescriptor();
+            PropertyPane.addComponent(currRow, tableLayout, pageUI, context, registry, descriptor);
+            currRow++;
+        }
+
+        pageUI.add(tableLayout.createVerticalSpacer());
+
+        JPanel parent = new JPanel(new BorderLayout());
+        parent.add(pageUI, BorderLayout.CENTER);
+        parent.add(Box.createHorizontalStrut(50), BorderLayout.EAST);
+        return parent;
+    }
+
+
+
+    @Override
+    protected void configure(BindingContext context) {
+
+        // Handle resetDefaults events - set all other components to defaults
+        restoreDefaults.addPropertyChangeListener(evt -> {
+            handleRestoreDefaults(context);
+        });
+
+
+
+        // Add listeners to all components in order to uncheck restoreDefaults checkbox accordingly
+
+        PropertySet propertyContainer = context.getPropertySet();
+        Property[] properties = propertyContainer.getProperties();
+
+        for (Property property : properties) {
+            if (property != restoreDefaults) {
+                property.addPropertyChangeListener(evt -> {
+                    handlePreferencesPropertyValueChange(context);
+                });
+            }
+        }
+    }
+
+
+
+
+
+
+    /**
+     * Test all properties to determine whether the current value is the default value
+     *
+     * @param context
+     * @return
+     * @author Daniel Knowles
+     */
+    private boolean isDefaults(BindingContext context) {
+
+        PropertySet propertyContainer = context.getPropertySet();
+        Property[] properties = propertyContainer.getProperties();
+
+        for (Property property : properties) {
+            if (property != restoreDefaults && property.getDescriptor().getDefaultValue() != null)
+                if (!property.getValue().equals(property.getDescriptor().getDefaultValue())) {
+                    return false;
+                }
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Handles the restore defaults action
+     *
+     * @param context
+     * @author Daniel Knowles
+     */
+    private void handleRestoreDefaults(BindingContext context) {
+        if (propertyValueChangeEventsEnabled) {
+            propertyValueChangeEventsEnabled = false;
+            try {
+                if (restoreDefaults.getValue()) {
+
+                    PropertySet propertyContainer = context.getPropertySet();
+                    Property[] properties = propertyContainer.getProperties();
+
+                    for (Property property : properties) {
+                        if (property != restoreDefaults && property.getDescriptor().getDefaultValue() != null)
+                            property.setValue(property.getDescriptor().getDefaultValue());
+                    }
+                }
+            } catch (ValidationException e) {
+                e.printStackTrace();
+            }
+            propertyValueChangeEventsEnabled = true;
+
+            context.setComponentsEnabled(PROPERTY_RESTORE_DEFAULTS_NAME, false);
+        }
+    }
+
+
+
+
+
+
+
+    /**
+     * Set restoreDefault component because a property has changed
+     * @param context
+     * @author Daniel Knowles
+     */
+    private void handlePreferencesPropertyValueChange(BindingContext context) {
+        if (propertyValueChangeEventsEnabled) {
+            propertyValueChangeEventsEnabled = false;
+            try {
+                restoreDefaults.setValue(isDefaults(context));
+                context.setComponentsEnabled(PROPERTY_RESTORE_DEFAULTS_NAME, !isDefaults(context));
+            } catch (ValidationException e) {
+                e.printStackTrace();
+            }
+            propertyValueChangeEventsEnabled = true;
+        }
+    }
+
+
+    /**
+     * Initialize the property descriptor default value
+     *
+     * @param context
+     * @param propertyName
+     * @param propertyDefault
+     * @return
+     * @author Daniel Knowles
+     */
+    private Property initPropertyDefaults(BindingContext context, String propertyName, Object propertyDefault) {
+
+        Property property = context.getPropertySet().getProperty(propertyName);
+
+        property.getDescriptor().setDefaultValue(propertyDefault);
+
+        return property;
+    }
+
+
+
+
+
+
+
+
+
+
+    @SuppressWarnings("UnusedDeclaration")
+    static class GeneralLayerBean {
+        
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_TOOLTIP)
+        boolean spectrumViewXaxisSetBoundsDefault = PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_TOOLTIP)
+        String spectrumViewXaxisMinDefault = PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_TOOLTIP)
+        String spectrumViewXaxisMaxDefault = PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_TOOLTIP)
+        boolean spectrumViewYaxisSetBoundsDefault = PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_TOOLTIP)
+        String spectrumViewYaxisMinDefault = PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_TOOLTIP)
+        String spectrumViewYaxisMaxDefault = PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_TITLE_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_TITLE_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_TITLE_TOOLTIP)
+        String spectrumViewTitleDefault = PROPERTY_SPECTRUM_VIEW_TITLE_DEFAULT;
+
+        
+//        @Preference(label = PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_LABEL,
+//                key = PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_KEY,
+//                description = PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_TOOLTIP)
+//        Color spectrumViewForegroundColorDefault = PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_TOOLTIP)
+        Color spectrumViewBackgroundColorDefault = PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_DEFAULT;
+
+//        @Preference(label = PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_LABEL,
+//                key = PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_KEY,
+//                description = PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_TOOLTIP)
+//        Color spectrumViewMarginBackgroundColorDefault = PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_DEFAULT;
+//
+//        @Preference(label = PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_LABEL,
+//                key = PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_KEY,
+//                description = PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_TOOLTIP)
+//        Color spectrumViewLegendBackgroundColorDefault = PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_DEFAULT;
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_TOOLTIP)
+        Color spectrumViewGridlineColorDefault = PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_DEFAULT;
+
+
+        @Preference(label = PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_LABEL,
+                key = PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_KEY,
+                description = PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_TOOLTIP)
+        boolean spectrumViewGridlineShowDefault = PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_DEFAULT;
+
+
+
+
+        
+        // Restore Defaults
+
+        @Preference(label = PROPERTY_RESTORE_SECTION_LABEL,
+                key = PROPERTY_RESTORE_SECTION_KEY,
+                description = PROPERTY_RESTORE_SECTION_TOOLTIP)
+        boolean restoreDefaultsSection = true;
+
+        @Preference(label = PROPERTY_RESTORE_DEFAULTS_LABEL,
+                key = PROPERTY_RESTORE_DEFAULTS_NAME,
+                description = PROPERTY_RESTORE_DEFAULTS_TOOLTIP)
+        boolean restoreDefaults = PROPERTY_RESTORE_DEFAULTS_DEFAULT;
+    }
+
+
+
+    public static boolean getPreferenceXaxisSetBounds() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyBool(PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_KEY, PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_DEFAULT);
+    }
+
+    public static String getPreferenceXaxisMin() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyString(PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_KEY, PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_DEFAULT);
+    }
+
+    public static String getPreferenceXaxisMax() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyString(PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_KEY, PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_DEFAULT);
+    }
+
+
+    public static boolean getPreferenceYaxisSetBounds() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyBool(PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_KEY, PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_DEFAULT);
+    }
+
+    public static String getPreferenceYaxisMin() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyString(PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_KEY, PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_DEFAULT);
+    }
+
+    public static String getPreferenceYaxisMax() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyString(PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_KEY, PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_DEFAULT);
+    }
+
+
+    public static String getPreferenceTitle() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyString(PROPERTY_SPECTRUM_VIEW_TITLE_KEY, PROPERTY_SPECTRUM_VIEW_TITLE_DEFAULT);
+    }
+
+
+
+//    public static Color getPreferenceForegroundColor() {
+//        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+//        return preferences.getPropertyColor(PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_DEFAULT);
+//    }
+
+    public static Color getPreferenceBackgroundColor() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyColor(PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_BACKGROUND_COLOR_DEFAULT);
+    }
+
+//    public static Color getPreferenceMarginBackgroundColor() {
+//        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+//        return preferences.getPropertyColor(PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_DEFAULT);
+//    }
+//
+//    public static Color getPreferenceLegendBackgroundColor() {
+//        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+//        return preferences.getPropertyColor(PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_DEFAULT);
+//    }
+
+
+
+    public static Color getPreferenceGridlinesColor() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyColor(PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_KEY, PROPERTY_SPECTRUM_VIEW_GRIDLINE_COLOR_DEFAULT);
+    }
+
+    public static boolean getPreferenceGridlinesShow() {
+        final PropertyMap preferences = SnapApp.getDefault().getAppContext().getPreferences();
+        return preferences.getPropertyBool(PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_KEY, PROPERTY_SPECTRUM_VIEW_GRIDLINE_SHOW_DEFAULT);
+    }
+}

--- a/snap-rcp/src/main/java/org/esa/snap/rcp/spectrum/SpectrumTopComponent.java
+++ b/snap-rcp/src/main/java/org/esa/snap/rcp/spectrum/SpectrumTopComponent.java
@@ -17,13 +17,16 @@ package org.esa.snap.rcp.spectrum;
 
 import com.bc.ceres.glayer.support.ImageLayer;
 import com.bc.ceres.glevel.MultiLevelModel;
+import com.bc.ceres.swing.progress.ProgressMonitorSwingWorker;
 import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.image.ImageManager;
 import org.esa.snap.core.util.ProductUtils;
 import org.esa.snap.core.util.StringUtils;
+import org.esa.snap.core.util.math.Array;
 import org.esa.snap.rcp.SnapApp;
 import org.esa.snap.rcp.actions.help.HelpAction;
 import org.esa.snap.rcp.placemark.PlacemarkUtils;
+import org.esa.snap.rcp.preferences.general.SpectrumViewController;
 import org.esa.snap.rcp.statistics.XYPlotMarker;
 import org.esa.snap.rcp.util.Dialogs;
 import org.esa.snap.rcp.windows.ToolTopComponent;
@@ -71,7 +74,10 @@ import java.beans.PropertyChangeListener;
 import java.util.List;
 import java.util.*;
 
-@TopComponent.Description(preferredID = "SpectrumTopComponent", iconBase = "org/esa/snap/rcp/icons/Spectrum.gif")
+@TopComponent.Description(preferredID = "SpectrumTopComponent",
+        iconBase = "org/esa/snap/rcp/icons/Spectrum.gif",
+        persistenceType = TopComponent.PERSISTENCE_NEVER
+)
 @TopComponent.Registration(mode = "Spectrum", openAtStartup = false, position = 80)
 @ActionID(category = "Window", id = "org.esa.snap.rcp.statistics.SpectrumTopComponent")
 @ActionReferences({
@@ -103,7 +109,29 @@ public class SpectrumTopComponent extends ToolTopComponent {
     private AbstractButton showSpectraForAllPinsButton;
     private AbstractButton showGridButton;
 
+    private JCheckBox rangeXCheckBox;
+    private JTextField rangeXLowerTextField;
+    private JLabel rangeXLowerLabel;
+    private JTextField rangeXUpperTextField;
+    private JLabel rangeXUpperLabel;
+
+    private JCheckBox rangeYCheckBox;
+    private JTextField rangeYLowerTextField;
+    private JLabel rangeYLowerLabel;
+    private JTextField rangeYUpperTextField;
+    private JLabel rangeYUpperLabel;
+
+    private boolean useRangeX;
+    private double rangeXLower;
+    private double rangeXUpper;
+
+    private boolean useRangeY;
+    private double rangeYLower;
+    private double rangeYUpper;
+
     private boolean tipShown;
+    private boolean spectrumViewToolIsOpen;
+    private boolean loadingPreferences;
     private ProductSceneView currentView;
     private Product currentProduct;
     private ChartPanel chartPanel;
@@ -115,6 +143,10 @@ public class SpectrumTopComponent extends ToolTopComponent {
     private boolean isUserInducedAutomaticAdjustmentChosen;
 
     public SpectrumTopComponent() {
+        // System.out.println("Spectrum View Tool is Open");
+        spectrumViewToolIsOpen = false;
+
+        tipShown = true;
         productNodeHandler = new ProductNodeHandler();
         pinSelectionChangeListener = new PinSelectionChangeListener();
         rasterToSpectraMap = new HashMap<>();
@@ -170,10 +202,138 @@ public class SpectrumTopComponent extends ToolTopComponent {
             if (currentView != null) {
                 currentView.addPropertyChangeListener(ProductSceneView.PROPERTY_NAME_SELECTED_PIN, pinSelectionChangeListener);
                 setCurrentProduct(currentView.getProduct());
+                if (currentProduct.getName().contains("SPEX")) {
+                    List<Integer> view_Angles = new ArrayList<Integer>();
+                    for (int  i = 0; i < currentProduct.getNumBands(); i++ ) {
+                        int viewAngle = (int) currentProduct.getBandAt(i).getAngularValue();
+                        if (!view_Angles.contains(viewAngle)) {
+                            view_Angles.add(viewAngle);
+                            if (view_Angles.size()  == 5) {
+                                break;
+                            }
+                        }
+                    }
+                    String autoGroupingStr = "QC:QC_bitwise:QC_polsample_bitwise:QC_polsample:";
+                    if (view_Angles != null) {
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "I_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "DOLP_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "AOLP_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "i_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "i_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "i_polsample_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "i_polsample_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "aolp_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "aolp_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "dolp_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "dolp_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "q_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "q_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "u_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "u_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "q_over_i_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "q_over_i_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "u_over_i_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "u_over_i_stdev_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "qc_" + view_Angles.get(i);
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "qc_polsample_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "i_noisefree_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "i_noisefree_polsample_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "dolp_noisefree_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "q_over_i_noisefree_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "aolp_noisefree_" + view_Angles.get(i) + "_*:";
+                        }
+                        for (int i = 0; i < 5; i ++) {
+                            autoGroupingStr += "u_over_i_noisefree_" + view_Angles.get(i) + "_*:";
+                        }
+                    }
+                    autoGroupingStr += "I:I_noise:I_noisefree:I_polsample:" +
+                            "I_polsample_noise:I_noisefree_polsample:DOLP:DOLP_noise:DOLP_noisefree:" +
+                            "Q_over_I:Q_over_I_noise:Q_over_I_noisefree:AOLP:AOLP_noise:AOLP_noisefree:" +
+                            "U_over_I:U_over_I_noise:U_over_I_noisefree:scattering_angle:rotation_angle:" +
+                            "sensor_azimuth:sensor_azimuth_angle:sensor_zenith:sensor_zenith_angle:"  +
+                            "solar_azimuth:solar_azimuth_angle:solar_zenith:solar_zenith_angle:" +
+                            "obs_per_view:view_time_offsets:number_of_observations";
+
+                    currentProduct.setAutoGrouping(autoGroupingStr);
+//                    currentProduct.setAutoGrouping("I:I_58_*:I_22_*:I_4_*:I_-22_*:I_-58_*:" +
+//                            "AOLP:AOLP_58_*:AOLP_22_*:AOLP_4_*:AOLP_-22_*:AOLP_-58_*:" +
+//                            "DOLP:DOLP_58_*:DOLP_22_*:DOLP_4_*:DOLP_-22_*:DOLP_-58_*:" +
+//                            "QC:QC_58_*:QC_22_*:QC_4_*:QC_-22_*:QC_-58_*:" +
+//                            "I_57_*:I_50_*:I_20_*:I_0_*:I_-20_*:I_-57_*:I_-50*:" +
+//                            "AOLP_57_*:AOLP_50:AOLP_20_*:AOLP_0_*:AOLP_-20_*:AOLP_-57_*:AOLP_-50" +
+//                            "DOLP_57_*:DOLP_20_*:DOLP_0_*:DOLP_-20_*:DOLP_-57_*:" +
+//                            "QC_57_*:QC_20_*:QC_0_*:QC_-22_*:QC_-57_*:" +
+//                            "QC_bitwise:QC_polsample_bitwise:QC_polsample:" +
+//                            "I_noise:I_noisefree:I_polsample:I_polsample_noise:I_noisefree_polsample:" +
+//                            "DOLP_noise:DOLP_noisefree:AOLP_noise:AOLP_noisefree:" +
+//                            "Q_over_I:Q_over_I_noise:Q_over_I_noisefree:" +
+//                            "U_over_I:U_over_I_noise:U_over_I_noisefree:scattering_angle:" +
+//                            "sensor_azimuth:sensor_zenith:solar_azimuth:solar_zenith:" +
+//                            "obs_per_view:view_time_offsets");
+                }
+
+                boolean showProgressMonitor = false;
+                if (getAllSpectra() == null && getAllSpectra().length == 0) {
+                    showProgressMonitor = true;
+                }
+
                 if (!rasterToSpectraMap.containsKey(currentView.getRaster())) {
+                    showProgressMonitor = true;
                     setUpSpectra();
                 }
-                recreateChart();
+
+                recreateChart(showProgressMonitor);
 
             }
             updateUIState();
@@ -220,20 +380,33 @@ public class SpectrumTopComponent extends ToolTopComponent {
         chartHandler.setCollectingSpectralInformationMessage();
     }
 
+
     void updateData(int pixelX, int pixelY, int level, boolean pixelPosInRasterBounds) {
-        chartHandler.setPosition(pixelX, pixelY, level, pixelPosInRasterBounds);
-        chartHandler.updateData();
+        updateData(pixelX, pixelY, level, pixelPosInRasterBounds, null,0);
     }
 
+    void updateData(int pixelX, int pixelY, int level, boolean pixelPosInRasterBounds, com.bc.ceres.core.ProgressMonitor pm, int totalWorkPlanned) {
+        chartHandler.setPosition(pixelX, pixelY, level, pixelPosInRasterBounds);
+        chartHandler.updateData(pm, totalWorkPlanned);
+    }
+
+
+
+
+
     void updateChart(boolean adjustAxes) {
+//        if (!loadingPreferences) {
         chartHandler.setAutomaticRangeAdjustments(adjustAxes);
         updateChart();
+//        }
     }
 
     void updateChart() {
+//        if (!loadingPreferences) {
         maybeShowTip();
         chartHandler.updateChart();
         chartPanel.repaint();
+//        }
     }
 
     private void maybeShowTip() {
@@ -293,8 +466,106 @@ public class SpectrumTopComponent extends ToolTopComponent {
         rangeAxisAdjustmentIsFrozen = false;
         chart.getXYPlot().getDomainAxis().setAutoRange(false);
         domainAxisAdjustmentIsFrozen = false;
+
+
+
+
+        rangeXCheckBox = new JCheckBox(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_LABEL);
+        rangeXCheckBox.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_SET_BOUNDS_TOOLTIP);
+
+        rangeXLowerLabel = new JLabel(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_LABEL);
+        rangeXLowerTextField = new JTextField("1234567890");
+        rangeXLowerLabel.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_TOOLTIP);
+        rangeXLowerTextField.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MIN_TOOLTIP);
+        rangeXLowerTextField.setMinimumSize(rangeXLowerTextField.getPreferredSize());
+        rangeXLowerTextField.setPreferredSize(rangeXLowerTextField.getPreferredSize());
+
+        rangeXUpperLabel = new JLabel(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_LABEL);
+        rangeXUpperTextField = new JTextField("1234567890");
+        rangeXUpperLabel.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_TOOLTIP);
+        rangeXUpperTextField.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_TOOLTIP);
+        rangeXUpperTextField.setMinimumSize(rangeXUpperTextField.getPreferredSize());
+        rangeXUpperTextField.setPreferredSize(rangeXUpperTextField.getPreferredSize());
+        rangeXUpperTextField.setText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_XAXIS_MAX_DEFAULT);
+
+
+
+        rangeYCheckBox = new JCheckBox(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_LABEL);
+        rangeYCheckBox.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_SET_BOUNDS_TOOLTIP);
+
+        rangeYLowerLabel = new JLabel(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_LABEL);
+        rangeYLowerTextField = new JTextField("1234567890");
+        rangeYLowerLabel.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_TOOLTIP);
+        rangeYLowerTextField.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MIN_TOOLTIP);
+        rangeYLowerTextField.setMinimumSize(rangeYLowerTextField.getPreferredSize());
+        rangeYLowerTextField.setPreferredSize(rangeYLowerTextField.getPreferredSize());
+
+        rangeYUpperLabel = new JLabel(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_LABEL);
+        rangeYUpperTextField = new JTextField("1234567890");
+        rangeYUpperLabel.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_TOOLTIP);
+        rangeYUpperTextField.setToolTipText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_TOOLTIP);
+        rangeYUpperTextField.setMinimumSize(rangeYUpperTextField.getPreferredSize());
+        rangeYUpperTextField.setPreferredSize(rangeYUpperTextField.getPreferredSize());
+        rangeYUpperTextField.setText(SpectrumViewController.PROPERTY_SPECTRUM_VIEW_YAXIS_MAX_DEFAULT);
+
+
+        rangeXLowerTextField.addActionListener(e -> {
+            if (!loadingPreferences) {
+                updateChart(false);
+            }
+        });
+        rangeXUpperTextField.addActionListener(e -> {
+            if (!loadingPreferences) {
+                updateChart(false);
+            }
+        });
+
+        rangeYLowerTextField.addActionListener(e -> {
+            if (!loadingPreferences) {
+                updateChart(false);
+            }
+        });
+        rangeYUpperTextField.addActionListener(e -> {
+            if (!loadingPreferences) {
+                updateChart(false);
+            }
+        });
+
+
+        rangeXCheckBox.addActionListener(e -> {
+            rangeXLowerLabel.setEnabled(rangeXCheckBox.isSelected());
+            rangeXLowerTextField.setEnabled(rangeXCheckBox.isSelected());
+            rangeXUpperLabel.setEnabled(rangeXCheckBox.isSelected());
+            rangeXUpperTextField.setEnabled(rangeXCheckBox.isSelected());
+            if (!loadingPreferences) {
+                if (rangeXCheckBox.isSelected()) {
+                    updateChart(false);
+                } else {
+                    updateChart(true);
+                }
+            }
+        });
+
+        rangeYCheckBox.addActionListener(e -> {
+            rangeYLowerLabel.setEnabled(rangeYCheckBox.isSelected());
+            rangeYLowerTextField.setEnabled(rangeYCheckBox.isSelected());
+            rangeYUpperLabel.setEnabled(rangeYCheckBox.isSelected());
+            rangeYUpperTextField.setEnabled(rangeYCheckBox.isSelected());
+            if (!loadingPreferences) {
+                if (rangeYCheckBox.isSelected()) {
+                    updateChart(false);
+                } else {
+                    updateChart(true);
+                }
+            }
+        });
+
+
+
         chartPanel = new ChartPanel(chart);
         chartHandler = new ChartHandler(chart);
+
+
         final XYPlotMarker plotMarker = new XYPlotMarker(chartPanel, new XYPlotMarker.Listener() {
             @Override
             public void pointSelected(XYDataset xyDataset, int seriesIndex, Point2D dataPoint) {
@@ -311,15 +582,34 @@ public class SpectrumTopComponent extends ToolTopComponent {
         filterButton.setName("filterButton");
         filterButton.setEnabled(false);
         filterButton.addActionListener(e -> {
+
+            final ProductSceneView selectedProductSceneView = getSelectedProductSceneView();
+            if (selectedProductSceneView != null) {
+                selectedProductSceneView.addPixelPositionListener(pixelPositionListener);
+                setCurrentView(selectedProductSceneView);
+            }
+
+            updateChart(true);
+
+            // System.out.println("Listening to filterButton");
+
             selectSpectralBands();
             recreateChart();
         });
 
         showSpectrumForCursorButton = ToolButtonFactory.createButton(
                 UIUtils.loadImageIcon("icons/CursorSpectrum24.gif"), true);
-        showSpectrumForCursorButton.addActionListener(e -> recreateChart());
+        showSpectrumForCursorButton.addActionListener(e -> {
+            if (showSpectrumForCursorButton.isSelected()) {
+                // System.out.println("Listening to showSpectrumForCursorButton - true");
+                runProgressMonitorForCursor();
+            } else {
+                // System.out.println("Listening to showSpectrumForCursorButton - false");
+                recreateChart();
+            }
+        });
         showSpectrumForCursorButton.setName("showSpectrumForCursorButton");
-        showSpectrumForCursorButton.setSelected(true);
+        showSpectrumForCursorButton.setSelected(false);
         showSpectrumForCursorButton.setToolTipText("Show spectrum at cursor position.");
 
         showSpectraForSelectedPinsButton = ToolButtonFactory.createButton(
@@ -330,9 +620,16 @@ public class SpectrumTopComponent extends ToolTopComponent {
             } else if (!isShowingSpectraForSelectedPins()) {
                 plotMarker.setInvisible();
             }
-            recreateChart();
+            if (showSpectraForSelectedPinsButton.isSelected()) {
+                // System.out.println("Listening to showSpectraForSelectedPinsButton - true");
+                recreateChart(true);
+            } else {
+                // System.out.println("Listening to showSpectraForSelectedPinsButton -false");
+                recreateChart();
+            }
         });
         showSpectraForSelectedPinsButton.setName("showSpectraForSelectedPinsButton");
+        showSpectraForSelectedPinsButton.setSelected(false);
         showSpectraForSelectedPinsButton.setToolTipText("Show spectra for selected pins.");
 
         showSpectraForAllPinsButton = ToolButtonFactory.createButton(UIUtils.loadImageIcon("icons/PinSpectra24.gif"),
@@ -343,15 +640,34 @@ public class SpectrumTopComponent extends ToolTopComponent {
             } else if (!isShowingSpectraForAllPins()) {
                 plotMarker.setInvisible();
             }
-            recreateChart();
+            if (showSpectraForAllPinsButton.isSelected()) {
+                // System.out.println("Listening to showSpectraForAllPinsButton - true");
+                recreateChart(true);
+            } else {
+                // System.out.println("Listening to showSpectraForAllPinsButton - false");
+                recreateChart();
+            }
         });
         showSpectraForAllPinsButton.setName("showSpectraForAllPinsButton");
+        showSpectraForAllPinsButton.setSelected(false);
         showSpectraForAllPinsButton.setToolTipText("Show spectra for all pins.");
 
         showGridButton = ToolButtonFactory.createButton(UIUtils.loadImageIcon("icons/SpectrumGrid24.gif"), true);
-        showGridButton.addActionListener(e -> chartHandler.setGridVisible(showGridButton.isSelected()));
+
+        showGridButton.addActionListener(e -> {
+            if (!loadingPreferences) {
+                chartHandler.setGridVisible(showGridButton.isSelected());
+            }
+        });
         showGridButton.setName("showGridButton");
         showGridButton.setToolTipText("Show diagram grid.");
+
+
+
+
+
+
+
 
         AbstractButton exportSpectraButton = ToolButtonFactory.createButton(UIUtils.loadImageIcon("icons/Export24.gif"),
                 false);
@@ -363,15 +679,19 @@ public class SpectrumTopComponent extends ToolTopComponent {
         helpButton.setName("helpButton");
         helpButton.setToolTipText("Help.");
 
+        loadPreferences();
+
 
         final JPanel buttonPane = GridBagUtils.createPanel();
         final GridBagConstraints gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.CENTER;
+        gbc.anchor = GridBagConstraints.WEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.insets.top = 2;
         gbc.gridy = 0;
+        gbc.gridwidth = 2;
         buttonPane.add(filterButton, gbc);
         gbc.gridy++;
+
         buttonPane.add(showSpectrumForCursorButton, gbc);
         gbc.gridy++;
         buttonPane.add(showSpectraForSelectedPinsButton, gbc);
@@ -379,19 +699,57 @@ public class SpectrumTopComponent extends ToolTopComponent {
         buttonPane.add(showSpectraForAllPinsButton, gbc);
         gbc.gridy++;
         buttonPane.add(showGridButton, gbc);
-        gbc.gridy++;
-        buttonPane.add(exportSpectraButton, gbc);
 
+
+        gbc.gridy++;
+        gbc.gridwidth = 2;
+        buttonPane.add(rangeXCheckBox, gbc);
+
+        gbc.gridy++;
+        gbc.gridx=0;
+        gbc.gridwidth = 1;
+        buttonPane.add(rangeXLowerLabel, gbc);
+        gbc.gridx=1;
+        buttonPane.add(rangeXLowerTextField, gbc);
+        gbc.gridy++;
+        gbc.gridx=0;
+        buttonPane.add(rangeXUpperLabel, gbc);
+        gbc.gridx=1;
+        buttonPane.add(rangeXUpperTextField, gbc);
+
+
+        gbc.gridy++;
+        gbc.gridx=0;
+        gbc.gridwidth = 2;
+        buttonPane.add(rangeYCheckBox, gbc);
+
+        gbc.gridy++;
+        gbc.gridx=0;
+        gbc.gridwidth = 1;
+        buttonPane.add(rangeYLowerLabel, gbc);
+        gbc.gridx=1;
+        buttonPane.add(rangeYLowerTextField, gbc);
+        gbc.gridy++;
+        gbc.gridx=0;
+        buttonPane.add(rangeYUpperLabel, gbc);
+        gbc.gridx=1;
+        buttonPane.add(rangeYUpperTextField, gbc);
+
+
+        gbc.gridwidth = 2;
+        gbc.gridy++;
+        gbc.gridx=0;
+        buttonPane.add(exportSpectraButton, gbc);
         gbc.gridy++;
         gbc.insets.bottom = 0;
         gbc.fill = GridBagConstraints.VERTICAL;
         gbc.weighty = 1.0;
         gbc.gridwidth = 2;
         buttonPane.add(new JLabel(" "), gbc); // filler
+        gbc.gridy++;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weighty = 0.0;
-        gbc.gridy = 10;
-        gbc.anchor = GridBagConstraints.EAST;
+        gbc.anchor = GridBagConstraints.SOUTHEAST;
         buttonPane.add(helpButton, gbc);
 
         chartPanel.setPreferredSize(new Dimension(300, 200));
@@ -444,6 +802,73 @@ public class SpectrumTopComponent extends ToolTopComponent {
         updateUIState();
     }
 
+    private void loadPreferences() {
+        loadingPreferences = true;
+
+        try {
+            chartHandler.chart.setTitle(SpectrumViewController.getPreferenceTitle());
+
+            rangeYCheckBox.setSelected(SpectrumViewController.getPreferenceYaxisSetBounds());
+            rangeYLowerTextField.setText(SpectrumViewController.getPreferenceYaxisMin());
+            rangeYUpperTextField.setText(SpectrumViewController.getPreferenceYaxisMax());
+
+            rangeXCheckBox.setSelected(SpectrumViewController.getPreferenceXaxisSetBounds());
+            rangeXLowerTextField.setText(SpectrumViewController.getPreferenceXaxisMin());
+            rangeXUpperTextField.setText(SpectrumViewController.getPreferenceXaxisMax());
+
+
+
+            Color gridlinesColor = SpectrumViewController.getPreferenceGridlinesColor();
+            chartHandler.chart.getXYPlot().setDomainGridlinePaint(gridlinesColor);
+            chartHandler.chart.getXYPlot().setRangeGridlinePaint(gridlinesColor);
+            chartHandler.chart.getXYPlot().setDomainMinorGridlinePaint(gridlinesColor);
+            chartHandler.chart.getXYPlot().setRangeMinorGridlinePaint(gridlinesColor);
+
+
+            Color plotBackgroundColor = SpectrumViewController.getPreferenceBackgroundColor();
+            chartHandler.chart.getPlot().setBackgroundPaint(plotBackgroundColor);
+            chartHandler.chart.getXYPlot().setBackgroundPaint(plotBackgroundColor);
+
+
+            Color foregroundColor = SpectrumViewController.PROPERTY_SPECTRUM_VIEW_FOREGROUND_COLOR_DEFAULT;
+
+            chartHandler.chart.getXYPlot().getRangeAxis().setTickMarkPaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getRangeAxis().setAxisLinePaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getDomainAxis().setTickMarkPaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getDomainAxis().setAxisLinePaint(foregroundColor);
+            chartHandler.chart.getTitle().setPaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getDomainAxis().setLabelPaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getRangeAxis().setLabelPaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getDomainAxis().setTickLabelPaint(foregroundColor);
+            chartHandler.chart.getXYPlot().getRangeAxis().setTickLabelPaint(foregroundColor);
+
+
+
+            Color marginBackgroundColor = SpectrumViewController.PROPERTY_SPECTRUM_VIEW_MARGIN_BACKGROUND_COLOR_DEFAULT;
+            chartHandler.chart.setBackgroundPaint(marginBackgroundColor);
+
+            Color legendBackgroundColor = SpectrumViewController.PROPERTY_SPECTRUM_VIEW_LEGEND_BACKGROUND_COLOR_DEFAULT;
+            chartHandler.chart.getLegend().setBackgroundPaint(legendBackgroundColor);
+
+
+            chartHandler.setGridVisible(SpectrumViewController.getPreferenceGridlinesShow());
+            showGridButton.setSelected(SpectrumViewController.getPreferenceGridlinesShow());
+
+            rangeXLowerLabel.setEnabled(rangeXCheckBox.isSelected());
+            rangeXLowerTextField.setEnabled(rangeXCheckBox.isSelected());
+            rangeXUpperLabel.setEnabled(rangeXCheckBox.isSelected());
+            rangeXUpperTextField.setEnabled(rangeXCheckBox.isSelected());
+            rangeYLowerLabel.setEnabled(rangeYCheckBox.isSelected());
+            rangeYLowerTextField.setEnabled(rangeYCheckBox.isSelected());
+            rangeYUpperLabel.setEnabled(rangeYCheckBox.isSelected());
+            rangeYUpperTextField.setEnabled(rangeYCheckBox.isSelected());
+        } catch (Exception e) {
+        }
+        loadingPreferences = false;
+
+
+    }
+
     private void selectSpectralBands() {
         final RasterDataNode currentRaster = currentView.getRaster();
         final DisplayableSpectrum[] allSpectra = rasterToSpectraMap.get(currentRaster);
@@ -466,12 +891,137 @@ public class SpectrumTopComponent extends ToolTopComponent {
         return showSpectraForAllPinsButton.isSelected();
     }
 
-    private void recreateChart() {
-        chartHandler.updateData();
-        chartHandler.updateChart();
-        chartPanel.repaint();
-        updateUIState();
+    private  void recreateChart() {
+        // System.out.println("INSIDE: recreateChart()");
+
+        recreateChart(false);
     }
+
+
+
+
+    private void runProgressMonitorForCursor() {
+        // System.out.println("INSIDE: runProgressMonitorForCursor - PROGRESS 1");
+
+        ProgressMonitorSwingWorker pmSwingWorker = new ProgressMonitorSwingWorker(SnapApp.getDefault().getMainFrame(),
+                "Collecting Spectral Data") {
+
+            @Override
+            protected Void doInBackground(com.bc.ceres.core.ProgressMonitor pm) throws Exception {
+
+                int totalWorkPlanned = 100;
+                pm.beginTask("Collecting spectral data: this can take several minutes on larger files", totalWorkPlanned);
+
+                try {
+                    // System.out.println("INSIDE: runProgressMonitorForCursor - PROGRESS 2");
+
+                    updateData(0, 0, 0, true, pm, (totalWorkPlanned - 10));
+                    chartHandler.setEmptyPlot();
+
+                    if (pm != null && pm.isCanceled()) {
+                        cancelActions();
+                        pm.done();
+                        return null;
+                    }
+
+                    chartPanel.repaint();
+
+                    updateUIState();
+                    // System.out.println("INSIDE: runProgressMonitorForCursor - PROGRESS 3");
+
+                } finally {
+                    // System.out.println("INSIDE: runProgressMonitorForCursor - PROGRESS Finally");
+
+                    if (pm != null && pm.isCanceled()) {
+                        cancelActions();
+                        return null;
+                    }
+                    pm.done();
+                }
+
+                // System.out.println("INSIDE: runProgressMonitorForCursor - PROGRESS END");
+
+                return null;
+            }
+        };
+
+        pmSwingWorker.executeWithBlocking();
+        // System.out.println("INSIDE: runProgressMonitorForCursor - PROGRESS END2");
+
+    }
+
+
+    private void recreateChart(boolean showProgress) {
+        // System.out.println("INSIDE: recreateChart(boolean showProgress)");
+        // System.out.println("SnapApp.getDefault().getInstanceName() = " + SnapApp.getDefault().getInstanceName() );
+
+        if (showProgress) {
+            // System.out.println("INSIDE: recreateChart(boolean showProgress) - PROGRESS 1");
+
+            ProgressMonitorSwingWorker pmSwingWorker = new ProgressMonitorSwingWorker(SnapApp.getDefault().getMainFrame(),
+                    "Collecting Spectral Data") {
+
+                @Override
+                protected Void doInBackground(com.bc.ceres.core.ProgressMonitor pm) throws Exception {
+
+                    int totalWorkPlanned = 100;
+                    pm.beginTask("Collecting spectral data: this can take several minutes on larger files", totalWorkPlanned);
+
+
+                    try {
+                        // System.out.println("INSIDE: recreateChart(boolean showProgress) - PROGRESS 2");
+
+                        chartHandler.updateData(pm,(totalWorkPlanned - 10));
+                        if (pm != null && pm.isCanceled()) {
+                            cancelActions();
+                            pm.done();
+                            return null;
+                        }
+
+                        chartHandler.updateChart();
+
+                        updateChart(true);
+                        if (pm != null) {
+                            pm.worked(1);
+                        }
+                        chartPanel.repaint();
+                        if (pm != null) {
+                            pm.worked(1);
+                        }
+                        updateUIState();
+                        // System.out.println("INSIDE: recreateChart(boolean showProgress) - PROGRESS 3");
+
+                    } finally {
+                        // System.out.println("INSIDE: recreateChart(boolean showProgress) - PROGRESS Finally");
+
+                        if (pm != null && pm.isCanceled()) {
+                            cancelActions();
+                            return null;
+                        }
+                        pm.done();
+                    }
+
+                    // System.out.println("INSIDE: recreateChart(boolean showProgress) - PROGRESS END");
+
+                    return null;
+                }
+            };
+
+            pmSwingWorker.executeWithBlocking();
+            // System.out.println("INSIDE: recreateChart(boolean showProgress) - PROGRESS END2");
+
+
+        } else {
+            // System.out.println("INSIDE: recreateChart(boolean showProgress) - NO PROGRESS");
+
+            chartHandler.updateData();
+            chartHandler.updateChart();
+            chartPanel.repaint();
+            updateUIState();
+            // System.out.println("INSIDE: recreateChart(boolean showProgress) - NO PROGRESS END");
+        }
+    }
+
 
     Placemark[] getDisplayedPins() {
         if (isShowingSpectraForSelectedPins() && currentView != null) {
@@ -520,6 +1070,9 @@ public class SpectrumTopComponent extends ToolTopComponent {
                 List<SpectrumBand> ungroupedBandsList = new ArrayList<>();
                 for (SpectrumBand availableSpectralBand : availableSpectralBands) {
                     final String bandName = availableSpectralBand.getName();
+                    if (currentProduct.getName().contains("SPEX")) {
+                        availableSpectralBand.setSelected(false);
+                    }
                     final int spectrumIndex = autoGrouping.indexOf(bandName);
                     if (spectrumIndex != -1) {
                         autoGroupingSpectra[spectrumIndex].addBand(availableSpectralBand);
@@ -581,32 +1134,93 @@ public class SpectrumTopComponent extends ToolTopComponent {
         chartHandler.removeCursorSpectraFromDataset();
     }
 
-    @Override
-    protected void productSceneViewSelected(ProductSceneView view) {
-        view.addPixelPositionListener(pixelPositionListener);
-        setCurrentView(view);
+
+    protected void cancelActions() {
+        showSpectraForAllPinsButton.setSelected(false);
+        showSpectrumForCursorButton.setSelected(false);
+        showSpectraForSelectedPinsButton.setSelected(false);
+
+        chartHandler.setEmptyPlot();
+        removeCursorSpectraFromDataset();
+        updateUIState();
     }
 
     @Override
+    protected void productSceneViewSelected(ProductSceneView view) {
+        if (spectrumViewToolIsOpen) {
+            showSpectraForAllPinsButton.setSelected(false);
+            showSpectrumForCursorButton.setSelected(false);
+            showSpectraForSelectedPinsButton.setSelected(false);
+            loadingPreferences = false;
+
+
+            // System.out.println("Listening: productSceneViewSelected");
+            view.addPixelPositionListener(pixelPositionListener);
+            setCurrentView(view);
+            updateChart(true);
+
+        }
+    }
+
+
+    @Override
     protected void productSceneViewDeselected(ProductSceneView view) {
-        view.removePixelPositionListener(pixelPositionListener);
-        setCurrentView(null);
+        if (spectrumViewToolIsOpen) {
+            showSpectraForAllPinsButton.setSelected(false);
+            showSpectrumForCursorButton.setSelected(false);
+            showSpectraForSelectedPinsButton.setSelected(false);
+            loadingPreferences = false;
+
+
+            // System.out.println("Listening: productSceneViewDeselected");
+            view.removePixelPositionListener(pixelPositionListener);
+            setCurrentView(null);
+            chartHandler.setEmptyPlot();
+        }
     }
 
     @Override
     protected void componentOpened() {
+        loadingPreferences = false;
+        // System.out.println("Listening: componentOpened");
+        spectrumViewToolIsOpen = true;
+
+        showSpectraForAllPinsButton.setSelected(false);
+        showSpectrumForCursorButton.setSelected(false);
+        showSpectraForSelectedPinsButton.setSelected(false);
+
         final ProductSceneView selectedProductSceneView = getSelectedProductSceneView();
         if (selectedProductSceneView != null) {
+
+
             selectedProductSceneView.addPixelPositionListener(pixelPositionListener);
             setCurrentView(selectedProductSceneView);
+//            loadPreferences();
+//            updateChart(true);
         }
+
+        loadPreferences();
+        updateChart(true);
     }
 
     @Override
     protected void componentClosed() {
+        // System.out.println("Listening: componentClosed");
+        spectrumViewToolIsOpen = false;
+        loadingPreferences = false;
+
+
+        showSpectraForAllPinsButton.setSelected(false);
+        showSpectrumForCursorButton.setSelected(false);
+        showSpectraForSelectedPinsButton.setSelected(false);
+
         if (currentView != null) {
             currentView.removePixelPositionListener(pixelPositionListener);
+            setCurrentView(null);
         }
+
+        chartHandler.setEmptyPlot();
+        removeCursorSpectraFromDataset();
     }
 
     public boolean showsValidCursorSpectra() {
@@ -616,7 +1230,6 @@ public class SpectrumTopComponent extends ToolTopComponent {
     Map<Placemark, Map<Band, Double>> getPinToEnergies() {
         return chartHandler.getPinToEnergies();
     }
-
     private class ChartHandler {
 
         private static final String MESSAGE_NO_SPECTRAL_BANDS = "No spectral bands available";   /*I18N*/
@@ -641,39 +1254,118 @@ public class SpectrumTopComponent extends ToolTopComponent {
         private void setAutomaticRangeAdjustments(boolean userInducesAutomaticAdjustment) {
             final XYPlot plot = chart.getXYPlot();
             boolean adjustmentHasChanged = false;
-            if (userInducesAutomaticAdjustment) {
-                if (!isUserInducedAutomaticAdjustmentChosen) {
-                    isUserInducedAutomaticAdjustmentChosen = true;
-                    if (!isAutomaticDomainAdjustmentSet()) {
+
+            // todo this block gets overridden due to presence of min/max fields, keep it until it is decided whether code is still useful
+//            if (userInducesAutomaticAdjustment) {
+//                if (!isUserInducedAutomaticAdjustmentChosen) {
+//                    isUserInducedAutomaticAdjustmentChosen = true;
+//                    if (!isAutomaticDomainAdjustmentSet()) {
+//                        plot.getDomainAxis().setAutoRange(true);
+//                        domainAxisAdjustmentIsFrozen = false;
+//                        adjustmentHasChanged = true;
+//                    }
+//                    if (!isAutomaticRangeAdjustmentSet()) {
+//                        plot.getRangeAxis().setAutoRange(true);
+//                        rangeAxisAdjustmentIsFrozen = false;
+//                        adjustmentHasChanged = true;
+//                    }
+//                }
+//            } else {
+//                if (isUserInducedAutomaticAdjustmentChosen) {
+//                    isUserInducedAutomaticAdjustmentChosen = false;
+//                    if (isAutomaticDomainAdjustmentSet()) {
+//                        plot.getDomainAxis().setAutoRange(false);
+//                        domainAxisAdjustmentIsFrozen = false;
+//                        adjustmentHasChanged = true;
+//                    }
+//                    if (isAutomaticRangeAdjustmentSet()) {
+//                        plot.getRangeAxis().setAutoRange(false);
+//                        rangeAxisAdjustmentIsFrozen = false;
+//                        adjustmentHasChanged = true;
+//                    }
+//                }
+//            }
+
+
+            //todo this block overrides previous block
+
+            domainAxisAdjustmentIsFrozen = false;
+            rangeAxisAdjustmentIsFrozen = false;
+
+            if (rangeXCheckBox.isSelected()) {
+                try {
+                    boolean validLower = false;
+                    boolean validUpper = false;
+                    if (rangeXLowerTextField.getText() != null && rangeXLowerTextField.getText().trim().length() > 0) {
+                        rangeXLower = Double.parseDouble(rangeXLowerTextField.getText());
+                        validLower = true;
+                    }
+
+                    if (rangeXUpperTextField.getText() != null && rangeXUpperTextField.getText().trim().length() > 0) {
+                        rangeXUpper = Double.parseDouble(rangeXUpperTextField.getText());
+                        validUpper = true;
+                    }
+
+                    if (validLower && validUpper) {
+                        plot.getDomainAxis().setRange(rangeXLower, rangeXUpper);
+                    } else {
                         plot.getDomainAxis().setAutoRange(true);
-                        domainAxisAdjustmentIsFrozen = false;
-                        adjustmentHasChanged = true;
+                        if (validLower) {
+                            plot.getDomainAxis().setLowerBound(rangeXLower);
+                        }
+                        if (validUpper) {
+                            plot.getDomainAxis().setUpperBound(rangeXUpper);
+                        }
                     }
-                    if (!isAutomaticRangeAdjustmentSet()) {
-                        plot.getRangeAxis().setAutoRange(true);
-                        rangeAxisAdjustmentIsFrozen = false;
-                        adjustmentHasChanged = true;
-                    }
+                    adjustmentHasChanged = true;
+                } catch (Exception e) {
                 }
             } else {
-                if (isUserInducedAutomaticAdjustmentChosen) {
-                    isUserInducedAutomaticAdjustmentChosen = false;
-                    if (isAutomaticDomainAdjustmentSet()) {
-                        plot.getDomainAxis().setAutoRange(false);
-                        domainAxisAdjustmentIsFrozen = false;
-                        adjustmentHasChanged = true;
-                    }
-                    if (isAutomaticRangeAdjustmentSet()) {
-                        plot.getRangeAxis().setAutoRange(false);
-                        rangeAxisAdjustmentIsFrozen = false;
-                        adjustmentHasChanged = true;
-                    }
-                }
+                plot.getDomainAxis().setAutoRange(true);
+                adjustmentHasChanged = true;
             }
+
+
+
+            if (rangeYCheckBox.isSelected()) {
+                try {
+                    boolean validLower = false;
+                    boolean validUpper = false;
+                    if (rangeYLowerTextField.getText() != null && rangeYLowerTextField.getText().trim().length() > 0) {
+                        rangeYLower = Double.parseDouble(rangeYLowerTextField.getText());
+                        validLower = true;
+                    }
+
+                    if (rangeYUpperTextField.getText() != null && rangeYUpperTextField.getText().trim().length() > 0) {
+                        rangeYUpper = Double.parseDouble(rangeYUpperTextField.getText());
+                        validUpper = true;
+                    }
+
+                    if (validLower && validUpper) {
+                        plot.getRangeAxis().setRange(rangeYLower, rangeYUpper);
+                    } else {
+                        plot.getRangeAxis().setAutoRange(true);
+                        if (validLower) {
+                            plot.getRangeAxis().setLowerBound(rangeYLower);
+                        }
+                        if (validUpper) {
+                            plot.getRangeAxis().setUpperBound(rangeYUpper);
+                        }
+                    }
+                    adjustmentHasChanged = true;
+                } catch (Exception e) {
+                }
+            } else {
+                plot.getRangeAxis().setAutoRange(true);
+                adjustmentHasChanged = true;
+            }
+
             if (adjustmentHasChanged) {
                 chartUpdater.invalidatePlotBounds();
             }
         }
+
+
 
         private boolean isAutomaticDomainAdjustmentSet() {
             return chart.getXYPlot().getDomainAxis().isAutoRange();
@@ -706,10 +1398,16 @@ public class SpectrumTopComponent extends ToolTopComponent {
             chart.getXYPlot().clearAnnotations();
         }
 
+
         private void updateData() {
-            List<DisplayableSpectrum> spectra = getSelectedSpectra();
-            chartUpdater.updateData(chart, spectra);
+            updateData(null, 0);
         }
+        private void updateData(com.bc.ceres.core.ProgressMonitor pm, int totalWorkPlanned) {
+            List<DisplayableSpectrum> spectra = getSelectedSpectra();
+            chartUpdater.updateData(chart, spectra, pm, totalWorkPlanned);
+        }
+
+
 
         private void setEmptyPlot() {
             chart.getXYPlot().setDataset(null);
@@ -759,7 +1457,6 @@ public class SpectrumTopComponent extends ToolTopComponent {
         public void setCollectingSpectralInformationMessage() {
             setPlotMessage(MESSAGE_COLLECTING_SPECTRAL_INFORMATION);
         }
-
         public Map<Placemark, Map<Band, Double>> getPinToEnergies() {
             return chartUpdater.getPinToEnergies();
         }
@@ -793,19 +1490,32 @@ public class SpectrumTopComponent extends ToolTopComponent {
         }
 
         private void setPosition(int pixelX, int pixelY, int level, boolean pixelPosInRasterBounds) {
-            rasterPixelX = pixelX;
-            rasterPixelY = pixelY;
-            rasterLevel = level;
+            this.rasterPixelX = pixelX;
+            this.rasterPixelY = pixelY;
+            this.rasterLevel = level;
             this.pixelPosInRasterBounds = pixelPosInRasterBounds;
             final AffineTransform i2m = currentView.getBaseImageLayer().getImageToModelTransform(level);
             modelP = i2m.transform(new Point2D.Double(pixelX + 0.5, pixelY + 0.5), new Point2D.Double());
         }
 
-        private void updateData(JFreeChart chart, List<DisplayableSpectrum> spectra) {
+        private void updateData(JFreeChart chart, List<DisplayableSpectrum> spectra, com.bc.ceres.core.ProgressMonitor pm, int totalWorkPlanned) {
             dataset = new XYSeriesCollection();
             if (rasterLevel >= 0) {
-                fillDatasetWithPinSeries(spectra, dataset, chart);
-                fillDatasetWithCursorSeries(spectra, dataset, chart);
+
+                if (getDisplayedPins().length > 0 && isShowingCursorSpectrum()) {
+                    totalWorkPlanned = totalWorkPlanned/2;
+                }
+
+                // System.out.println("totalWorkPlanned=" + totalWorkPlanned);
+
+                fillDatasetWithPinSeries(spectra, dataset, chart, pm, totalWorkPlanned);
+                // System.out.println("Finish fillDatasetWithPinSeries");
+
+                if (pm != null && pm.isCanceled()) {
+                    cancelActions();
+                    return;
+                }
+                fillDatasetWithCursorSeries(spectra, dataset, chart, pm, totalWorkPlanned);
             }
         }
 
@@ -846,10 +1556,10 @@ public class SpectrumTopComponent extends ToolTopComponent {
         private void updatePlotBounds(Range newBounds, ValueAxis axis, int index) {
             if (newBounds != null) {
                 final Range axisBounds = axis.getRange();
-                final Range oldBounds = plotBounds[index];
-                plotBounds[index] = getNewRange(newBounds, plotBounds[index], axisBounds);
-                if (oldBounds != plotBounds[index]) {
-                    axis.setRange(getNewPlotBounds(plotBounds[index]));
+                final Range oldBounds = this.plotBounds[index];
+                this.plotBounds[index] = getNewRange(newBounds, this.plotBounds[index], axisBounds);
+                if (oldBounds != this.plotBounds[index]) {
+                    axis.setRange(getNewPlotBounds(this.plotBounds[index]));
                 }
             }
         }
@@ -874,25 +1584,52 @@ public class SpectrumTopComponent extends ToolTopComponent {
                     bounds.getUpperBound() + delta);
         }
 
-        private void fillDatasetWithCursorSeries(List<DisplayableSpectrum> spectra, XYSeriesCollection dataset, JFreeChart chart) {
+        private void fillDatasetWithCursorSeries(List<DisplayableSpectrum> spectra, XYSeriesCollection dataset, JFreeChart chart, com.bc.ceres.core.ProgressMonitor pm, int totalWorkPlanned) {
             showsValidCursorSpectra = false;
             if (modelP == null) {
                 return;
             }
             if (isShowingCursorSpectrum() && currentView != null) {
+                int totalWorkPlannedPerSpectra = (int) Math.floor(1.0 * totalWorkPlanned / spectra.size());
+                int workDone = 0;
+
                 for (DisplayableSpectrum spectrum : spectra) {
                     XYSeries series = new XYSeries(spectrum.getName());
                     final Band[] spectralBands = spectrum.getSelectedBands();
+
+                    int numBands = spectralBands.length;
+                    double incrementLengthNumBands = (totalWorkPlannedPerSpectra > 0) ? numBands / totalWorkPlannedPerSpectra : numBands;
+                    double nextIncrementFinishedBandCount = incrementLengthNumBands;
+                    int bandCount = 0;
+
                     if (!currentProduct.isMultiSize()) {
+
                         for (Band spectralBand : spectralBands) {
+                            if (pm != null && pm.isCanceled()) {
+                                cancelActions();
+                                return;
+                            }
                             final float wavelength = spectralBand.getSpectralWavelength();
                             if (pixelPosInRasterBounds && isPixelValid(spectralBand, rasterPixelX, rasterPixelY, rasterLevel)) {
                                 addToSeries(spectralBand, rasterPixelX, rasterPixelY, rasterLevel, series, wavelength);
                                 showsValidCursorSpectra = true;
                             }
+
+                            bandCount++;
+                            if (workDone < totalWorkPlanned && bandCount > nextIncrementFinishedBandCount) {
+                                if (totalWorkPlanned != 0) {
+                                    if (pm != null) {pm.worked(1);}
+                                }
+                                nextIncrementFinishedBandCount += incrementLengthNumBands;
+                                workDone++;
+                            }
                         }
                     } else {
                         for (Band spectralBand : spectralBands) {
+                            if (pm != null && pm.isCanceled()) {
+                                cancelActions();
+                                return;
+                            }
                             final float wavelength = spectralBand.getSpectralWavelength();
                             final AffineTransform i2m = spectralBand.getImageToModelTransform();
                             if (i2m.equals(currentView.getRaster().getImageToModelTransform())) {
@@ -914,9 +1651,26 @@ public class SpectrumTopComponent extends ToolTopComponent {
                                     showsValidCursorSpectra = true;
                                 }
                             }
+
+                            bandCount++;
+                            if (workDone < totalWorkPlanned && bandCount > nextIncrementFinishedBandCount) {
+                                if (totalWorkPlanned != 0) {
+                                    if (pm != null) {pm.worked(1);}
+                                }
+                                nextIncrementFinishedBandCount += incrementLengthNumBands;
+                                workDone++;
+                            }
                         }
                     }
+                    if (pm != null && pm.isCanceled()) {
+                        cancelActions();
+                        return;
+                    }
                     updateRenderer(dataset.getSeriesCount(), Color.BLACK, spectrum, chart);
+                    if (pm != null && pm.isCanceled()) {
+                        cancelActions();
+                        return;
+                    }
                     dataset.addSeries(series);
                 }
             }
@@ -935,18 +1689,36 @@ public class SpectrumTopComponent extends ToolTopComponent {
             return x >= 0 && y >= 0 && x < levelImage.getWidth() && y < levelImage.getHeight();
         }
 
-        private void fillDatasetWithPinSeries(List<DisplayableSpectrum> spectra, XYSeriesCollection dataset, JFreeChart chart) {
+        private void fillDatasetWithPinSeries(List<DisplayableSpectrum> spectra, XYSeriesCollection dataset, JFreeChart chart, com.bc.ceres.core.ProgressMonitor pm, int totalWorkPlanned) {
             Placemark[] pins = getDisplayedPins();
+
+            totalWorkPlanned = (int) Math.floor(1.0 * totalWorkPlanned / pins.length);
+            // System.out.println("Number of pins =" + pins.length);
+            // System.out.println("(For each pin) totalWorkPlanned=" + totalWorkPlanned);
+
             for (Placemark pin : pins) {
-                List<XYSeries> pinSeries = createXYSeriesFromPin(pin, dataset.getSeriesCount(), spectra, chart);
+                List<XYSeries> pinSeries = createXYSeriesFromPin(pin, dataset.getSeriesCount(), spectra, chart, pm, totalWorkPlanned);
+                if (pm != null && pm.isCanceled()) {
+                    cancelActions();
+                    return;
+                }
                 pinSeries.forEach(dataset::addSeries);
             }
         }
 
-        private List<XYSeries> createXYSeriesFromPin(Placemark pin, int seriesIndex, List<DisplayableSpectrum> spectra, JFreeChart chart) {
+        private List<XYSeries> createXYSeriesFromPin(Placemark pin, int seriesIndex, List<DisplayableSpectrum> spectra, JFreeChart chart, com.bc.ceres.core.ProgressMonitor pm, int totalWorkPlanned) {
             List<XYSeries> pinSeries = new ArrayList<>();
             Color pinColor = PlacemarkUtils.getPlacemarkColor(pin, currentView);
+
+            int totalWorkPlannedPerSpectra = (int) Math.floor(1.0 * totalWorkPlanned / spectra.size());
+            int workDone = 0;
+            // System.out.println("totalWorkPlannedPerSpectra=" + totalWorkPlannedPerSpectra);
+
             for (DisplayableSpectrum spectrum : spectra) {
+                if (pm != null && pm.isCanceled()) {
+                    cancelActions();
+                    return null;
+                }
                 XYSeries series = new XYSeries(spectrum.getName() + "_" + pin.getLabel());
                 final Band[] spectralBands = spectrum.getSelectedBands();
                 Map<Band, Double> bandToEnergy;
@@ -956,7 +1728,18 @@ public class SpectrumTopComponent extends ToolTopComponent {
                     bandToEnergy = new HashMap<>();
                     pinToEnergies.put(pin, bandToEnergy);
                 }
+
+                int numBands = spectralBands.length;
+                double incrementLengthNumBands = (totalWorkPlannedPerSpectra > 0) ? numBands / totalWorkPlannedPerSpectra : numBands;
+                // System.out.println("incrementLengthNumBands=" + incrementLengthNumBands);
+                double nextIncrementFinishedBandCount = incrementLengthNumBands;
+                int bandCount = 0;
+
                 for (Band spectralBand : spectralBands) {
+                    if (pm != null && pm.isCanceled()) {
+                        cancelActions();
+                        return null;
+                    }
                     double energy;
                     if (bandToEnergy.containsKey(spectralBand)) {
                         energy = bandToEnergy.get(spectralBand);
@@ -968,9 +1751,27 @@ public class SpectrumTopComponent extends ToolTopComponent {
                     if (energy != spectralBand.getGeophysicalNoDataValue()) {
                         series.add(wavelength, energy);
                     }
+
+                    bandCount++;
+                    if (workDone < totalWorkPlanned && bandCount > nextIncrementFinishedBandCount) {
+                        if (totalWorkPlanned != 0) {
+                            if (pm != null) {pm.worked(1);}
+                        }
+                        nextIncrementFinishedBandCount += incrementLengthNumBands;
+                        workDone++;
+                    }
+                }
+
+                if (pm != null && pm.isCanceled()) {
+                    cancelActions();
+                    return null;
                 }
                 updateRenderer(seriesIndex, pinColor, spectrum, chart);
                 seriesIndex++;
+                if (pm != null && pm.isCanceled()) {
+                    cancelActions();
+                    return null;
+                }
                 pinSeries.add(series);
             }
             return pinSeries;


### PR DESCRIPTION
This modifies the Spectrum View tool:
1. Fixes issues with freeze ups due to large PACE files.
2. Adds progress monitor (PACE files can take several minutes to run)
3. Resets all fields when spectrum view tool is closed (previously the cursor tracking could be left on and bog down other files even though spectrum view was closed)
4. Adds domain and range settings
5. Adds a Preference page

Note: this pull request is dependent on the snap-engine pull request for "SEADAS-angular-NSIDC-11.0.0-04-30-24" or "SEADAS-reproject-11.0.0-04-30-24"