### PR TITLE
SNAP-3844 disable TopSecurityManager in snap.conf

### DIFF
--- a/etc/snap.conf
+++ b/etc/snap.conf
@@ -7,7 +7,7 @@
 default_userdir="${HOME}/.snap"
 
 # options used by the launcher by default, can be overridden by explicit command line switches
-default_options="--branding ${branding.token} -J-Xms24m --locale en_GB  -J-Dnetbeans.mainclass=org.esa.snap.main.Main -J-Dsun.java2d.noddraw=true -J-Dsun.awt.nopixfmt=true -J-Dsun.java2d.dpiaware=false"
+default_options="--branding ${branding.token} -J-Xms24m --locale en_GB  -J-Dnetbeans.mainclass=org.esa.snap.main.Main -J-Dsun.java2d.noddraw=true -J-Dsun.awt.nopixfmt=true -J-Dsun.java2d.dpiaware=false -J-DTopSecurityManager.disable=true"
 # for development purposes you may wish to append: -J-Dnetbeans.logger.console=true -J-ea
 
 # default location of JDK/JRE, can be overridden by using --jdkhome <dir> switch (not used in development mode)


### PR DESCRIPTION
From Marco's suggestion to improve dialog performance
Disable TopSecurityManager in snap.conf